### PR TITLE
feat: add safe-try function to handle happy path easily

### DIFF
--- a/packages/byethrow/src/functions/safe-try.test.ts
+++ b/packages/byethrow/src/functions/safe-try.test.ts
@@ -1,0 +1,65 @@
+import { safeTry } from "./safe-try";
+import { fail } from './fail';
+import { succeed } from './succeed';
+import { describe, it } from 'vitest';
+import { isFailure } from "./is-failure";
+import { random } from "effect/Hash";
+
+describe('safeTry', () => {
+  it('should return all the failures', () => {
+    function generateRandomNumber() {
+      const randomNumber = Math.floor(Math.random() * 100)
+      if (randomNumber > 80) {
+        return fail('RandomError' as const)
+      }
+
+      return succeed(randomNumber)
+    }
+
+    const divide = (a: number, b: number) => {
+      if (b === 0) {
+        return fail('DivideByZeroError' as const)
+      }
+      return succeed(a / b)
+    }
+
+
+    const safePrompt = (_message: string) => {
+      const value = '0' as string | null // prompt(message) simulate fake user prompt
+      if (value === null) {
+        return fail('PromptCancelledError' as const)
+      }
+      return succeed(value)
+    }
+
+    const res = safeTry(function*(_) {
+      const randomNumber = yield* _(generateRandomNumber())
+      console.log(`got random number: ${randomNumber}`)
+
+      const value = parseInt(yield* _(safePrompt('Enter a number')))
+
+      const result = yield* _(divide(randomNumber, value))
+
+      return succeed(result)
+    })
+
+    if (isFailure(res)) {
+      switch (res.error) {
+        case 'RandomError': {
+          console.log('something went wrong')
+          break
+        }
+        case 'DivideByZeroError': {
+          console.log('cant divide by zero')
+          break
+        }
+        case 'PromptCancelledError': {
+          console.log('cancelled by user')
+          break
+        }
+      }
+    } else {
+      console.log(`result is ${res.value}`)
+    }
+  })
+})

--- a/packages/byethrow/src/functions/safe-try.ts
+++ b/packages/byethrow/src/functions/safe-try.ts
@@ -1,0 +1,23 @@
+import type { Failure, Result } from "../result";
+
+function wrapper<T, E>(value: Result<T, E>) {
+  return {
+    ...value,
+    *[Symbol.iterator]() {
+      if (value.type === 'Success') {
+        return value.value
+      } else {
+        yield value
+        throw 'unreachable'
+      }
+    }
+  }
+}
+
+type Wrapper = typeof wrapper
+
+
+export function safeTry<T, E>(body: (_: Wrapper) => Generator<Failure<E>, Result<T, E>>): Result<T, E> {
+  const n = body(wrapper).next()
+  return n.value
+}


### PR DESCRIPTION
this is a draft to experiment with this feature. I am not sure there is an equivalent yet in the package.

I wanted to see if it was possible to add the same `safeTry` function as the one from [neverthrow package](https://github.com/supermacro/neverthrow#safetry). 

For the api I went with a callback function that has as an argument what I called a `Wrapper` (I don't think the name is correct though), that adds a `*[Symbol.iterator]` method on the `Result` value.

this is the same API as effect had a while ago with [`Effect.gen(function*(_))`](https://effect.website/docs/getting-started/using-generators/#adapter)

for the moment I've added an example of the usage in the test file
the `res` variable does have all the errors in its type signature.
```ts
Result<number, "RandomError" | "DivideByZeroError" | "PromptCancelledError">
```

what do you think of such feature?