### PR TITLE
chore: Add link for official documentation on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Introduction
 
-`@praha/byethrow` is a lightweight, tree-shakable Result type package with a simple, consistent API designed to handle fallible operations in JavaScript and TypeScript. It provides a straightforward way to manage errors and results without the complexity of larger libraries.
+`@praha/byethrow` is a lightweight, tree-shakable Result type package with a simple, consistent API designed to handle fallible operations in JavaScript and TypeScript. It provides a straightforward way to manage errors and results without the complexity of larger libraries. For a usage guide, visit the [official documentation](https://praha-inc.github.io/byethrow/).
 
 ## Structure
 


### PR DESCRIPTION
This pull request updates `README.md` to add direct links to the official documentation, making it easier to access the usage guide.

Documentation update:

* Added a link to the [official documentation](https://praha-inc.github.io/byethrow/) in the introduction section of `README.md` to help users find usage guides more easily.