### PR TITLE
chore: fetch full git history for correct last updated dates on website

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
 
       - name: Setup
         uses: ./.github/actions/setup


### PR DESCRIPTION
## Summary

Rspress's `lastUpdated` retrieves the last commit timestamp for each file via `git log -1 --format=%at <file>`.

Since `actions/checkout` defaults to shallow clone (depth 1), all pages were showing the deploy date instead of each file's actual last commit date.

Added `fetch-depth: 0` to fetch full git history.

ref: https://rspress.rs/guide/basic/deploy