### PR TITLE
bugfix: adjust CJS output for compatibility with all module resolutions

### DIFF
--- a/.changeset/dark-clocks-film.md
+++ b/.changeset/dark-clocks-film.md
@@ -1,0 +1,7 @@
+---
+"@praha/byethrow": patch
+"@praha/byethrow-docs": patch
+"@praha/byethrow-testing": patch
+---
+
+Fix `node` and `node16` module resolution for the CJS output.

--- a/packages/byethrow/package.json
+++ b/packages/byethrow/package.json
@@ -24,7 +24,7 @@
   "type": "module",
   "exports": {
     "require": {
-      "types": "./dist/cjs/index.d.ts",
+      "types": "./dist/cjs/index.d.cts",
       "default": "./dist/cjs/index.cjs"
     },
     "import": {
@@ -34,7 +34,7 @@
   },
   "main": "./dist/cjs/index.cjs",
   "module": "./dist/esm/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./dist/cjs/index.d.cts",
   "files": [
     "dist",
     "LICENSE",

--- a/packages/byethrow/rslib.config.ts
+++ b/packages/byethrow/rslib.config.ts
@@ -5,7 +5,9 @@ import type { Format, LibConfig } from '@rslib/core';
 const createLibrary = (format: Format): LibConfig => ({
   format,
   bundle: false,
-  dts: true,
+  dts: {
+    autoExtension: true,
+  },
   redirect: {
     dts: {
       extension: true,

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -25,7 +25,7 @@
   "type": "module",
   "exports": {
     "require": {
-      "types": "./dist/cjs/index.d.ts",
+      "types": "./dist/cjs/index.d.cts",
       "default": "./dist/cjs/index.cjs"
     },
     "import": {
@@ -35,7 +35,7 @@
   },
   "main": "./dist/cjs/index.cjs",
   "module": "./dist/esm/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./dist/cjs/index.d.cts",
   "bin": {
     "byethrow-docs": "./bin/cli.js"
   },

--- a/packages/docs/rslib.config.ts
+++ b/packages/docs/rslib.config.ts
@@ -7,7 +7,9 @@ import type { Format, LibConfig } from '@rslib/core';
 const createLibrary = (format: Format): LibConfig => ({
   format,
   bundle: false,
-  dts: true,
+  dts: {
+    autoExtension: true,
+  },
   redirect: {
     dts: {
       extension: true,

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -25,7 +25,7 @@
   "type": "module",
   "exports": {
     "require": {
-      "types": "./dist/cjs/index.d.ts",
+      "types": "./dist/cjs/index.d.cts",
       "default": "./dist/cjs/index.cjs"
     },
     "import": {
@@ -35,7 +35,7 @@
   },
   "main": "./dist/cjs/index.cjs",
   "module": "./dist/esm/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./dist/cjs/index.d.cts",
   "files": [
     "dist",
     "LICENSE",

--- a/packages/testing/rslib.config.ts
+++ b/packages/testing/rslib.config.ts
@@ -5,7 +5,9 @@ import type { Format, LibConfig } from '@rslib/core';
 const createLibrary = (format: Format): LibConfig => ({
   format,
   bundle: false,
-  dts: true,
+  dts: {
+    autoExtension: true,
+  },
   redirect: {
     dts: {
       extension: true,


### PR DESCRIPTION
Pretty straightforward I'd say.

Fixes: #721
Supersedes #722 as it seems you've got branch naming rules.