### PR TITLE
feat(byethrow)!: Remove Promise auto-await from succeed/fail

### DIFF
--- a/.changeset/remove-promise-auto-await.md
+++ b/.changeset/remove-promise-auto-await.md
@@ -1,0 +1,9 @@
+---
+"@praha/byethrow": minor
+---
+
+Remove Promise auto-await from succeed/fail
+
+**BREAKING CHANGES:**
+
+`succeed` and `fail` no longer detect and auto-await `Promise` arguments. Passing a `Promise` now flows straight through as the wrapped value/error instead of resolving into a `ResultAsync`. Await the `Promise` yourself before calling `succeed`/`fail`, e.g. `succeed(await promise)` instead of `succeed(promise)`.

--- a/packages/byethrow/src/functions/and-then.test-d.ts
+++ b/packages/byethrow/src/functions/and-then.test-d.ts
@@ -35,7 +35,7 @@ describe('andThen', () => {
       });
 
       describe('when output is asynchronous (Promise)', () => {
-        const transform = (x: number) => succeed(Promise.resolve(x.toString()));
+        const transform = (x: number) => Promise.resolve(succeed(x.toString()));
 
         describe('when input is a success', () => {
           const input = succeed(2);
@@ -64,7 +64,7 @@ describe('andThen', () => {
         const transform = (x: number) => succeed(x.toString());
 
         describe('when input is a success', () => {
-          const input = succeed(Promise.resolve(2));
+          const input = Promise.resolve(succeed(2));
 
           it('should return a ResultAsync with transformed value', () => {
             const result = andThen(transform)(input);
@@ -74,21 +74,21 @@ describe('andThen', () => {
         });
 
         describe('when input is a failure', () => {
-          const input = fail(Promise.resolve('error'));
+          const input = Promise.resolve(fail('error'));
 
           it('should return a ResultAsync with original error', () => {
             const result = andThen(transform)(input);
 
-            expectTypeOf(result).toEqualTypeOf<ResultAsync<string, string>>();
+            expectTypeOf(result).toEqualTypeOf<ResultAsync<string, 'error'>>();
           });
         });
       });
 
       describe('when output is asynchronous (Promise)', () => {
-        const transform = (x: number) => succeed(Promise.resolve(x.toString()));
+        const transform = (x: number) => Promise.resolve(succeed(x.toString()));
 
         describe('when input is a success', () => {
-          const input = succeed(Promise.resolve(2));
+          const input = Promise.resolve(succeed(2));
 
           it('should return a ResultAsync with transformed value', () => {
             const result = andThen(transform)(input);
@@ -98,12 +98,12 @@ describe('andThen', () => {
         });
 
         describe('when input is a failure', () => {
-          const input = fail(Promise.resolve('error'));
+          const input = Promise.resolve(fail('error'));
 
           it('should return a ResultAsync with original error', () => {
             const result = andThen(transform)(input);
 
-            expectTypeOf(result).toEqualTypeOf<ResultAsync<string, string>>();
+            expectTypeOf(result).toEqualTypeOf<ResultAsync<string, 'error'>>();
           });
         });
       });
@@ -147,7 +147,7 @@ describe('andThen', () => {
           it('should return a ResultAsync with transformed value', () => {
             const result = pipe(
               input,
-              andThen((x) => succeed(Promise.resolve(x.toString()))),
+              andThen((x) => Promise.resolve(succeed(x.toString()))),
             );
 
             expectTypeOf(result).toEqualTypeOf<ResultAsync<string, never>>();
@@ -160,7 +160,7 @@ describe('andThen', () => {
           it('should return a ResultAsync with original error', () => {
             const result = pipe(
               input,
-              andThen((x) => succeed(Promise.resolve(x.toString()))),
+              andThen((x) => Promise.resolve(succeed(x.toString()))),
             );
 
             expectTypeOf(result).toEqualTypeOf<ResultAsync<string, string>>();
@@ -172,7 +172,7 @@ describe('andThen', () => {
     describe('when input is asynchronous (Promise)', () => {
       describe('when output is synchronous', () => {
         describe('when input is a success', () => {
-          const input = succeed(Promise.resolve(2));
+          const input = Promise.resolve(succeed(2));
 
           it('should return a ResultAsync with transformed value', () => {
             const result = pipe(
@@ -185,7 +185,7 @@ describe('andThen', () => {
         });
 
         describe('when input is a failure', () => {
-          const input: ResultAsync<number, string> = fail(Promise.resolve('error'));
+          const input: ResultAsync<number, string> = Promise.resolve(fail('error'));
 
           it('should return a ResultAsync with original error', () => {
             const result = pipe(
@@ -200,12 +200,12 @@ describe('andThen', () => {
 
       describe('when output is asynchronous (Promise)', () => {
         describe('when input is a success', () => {
-          const input = succeed(Promise.resolve(2));
+          const input = Promise.resolve(succeed(2));
 
           it('should return a ResultAsync with transformed value', () => {
             const result = pipe(
               input,
-              andThen((x) => succeed(Promise.resolve(x.toString()))),
+              andThen((x) => Promise.resolve(succeed(x.toString()))),
             );
 
             expectTypeOf(result).toEqualTypeOf<ResultAsync<string, never>>();
@@ -213,12 +213,12 @@ describe('andThen', () => {
         });
 
         describe('when input is a failure', () => {
-          const input: ResultAsync<number, string> = fail(Promise.resolve('error'));
+          const input: ResultAsync<number, string> = Promise.resolve(fail('error'));
 
           it('should return a ResultAsync with original error', () => {
             const result = pipe(
               input,
-              andThen((x) => succeed(Promise.resolve(x.toString()))),
+              andThen((x) => Promise.resolve(succeed(x.toString()))),
             );
 
             expectTypeOf(result).toEqualTypeOf<ResultAsync<string, string>>();

--- a/packages/byethrow/src/functions/and-then.test.ts
+++ b/packages/byethrow/src/functions/and-then.test.ts
@@ -43,7 +43,7 @@ describe('andThen', () => {
     });
 
     describe('when output is asynchronous (Promise)', () => {
-      const transform = vi.fn((x: number) => succeed(Promise.resolve(x.toString())));
+      const transform = vi.fn((x: number) => Promise.resolve(succeed(x.toString())));
 
       describe('when input is a success', () => {
         const input = succeed(2);
@@ -84,7 +84,7 @@ describe('andThen', () => {
       const transform = vi.fn((x: number) => succeed(x.toString()));
 
       describe('when input is a success', () => {
-        const input = succeed(Promise.resolve(2));
+        const input = Promise.resolve(succeed(2));
 
         it('should apply the function to the input', async () => {
           const result = await andThen(transform)(input);
@@ -100,7 +100,7 @@ describe('andThen', () => {
       });
 
       describe('when input is a failure', () => {
-        const input = fail(Promise.resolve('error'));
+        const input = Promise.resolve(fail('error'));
 
         it('should return the same failure', async () => {
           const result = await andThen(transform)(input);
@@ -117,10 +117,10 @@ describe('andThen', () => {
     });
 
     describe('when output is asynchronous (Promise)', () => {
-      const transform = vi.fn((x: number) => succeed(Promise.resolve(x.toString())));
+      const transform = vi.fn((x: number) => Promise.resolve(succeed(x.toString())));
 
       describe('when input is a success', () => {
-        const input = succeed(Promise.resolve(2));
+        const input = Promise.resolve(succeed(2));
 
         it('should apply the function to the input', async () => {
           const result = await andThen(transform)(input);
@@ -136,7 +136,7 @@ describe('andThen', () => {
       });
 
       describe('when input is a failure', () => {
-        const input = fail(Promise.resolve('error'));
+        const input = Promise.resolve(fail('error'));
 
         it('should return the same failure', async () => {
           const result = await andThen(transform)(input);

--- a/packages/byethrow/src/functions/and-through.test-d.ts
+++ b/packages/byethrow/src/functions/and-through.test-d.ts
@@ -62,7 +62,7 @@ describe('andThrough', () => {
 
       describe('when output is asynchronous (Promise)', () => {
         describe('when output is a success', () => {
-          const transform = (x: number) => succeed(Promise.resolve(x.toString()));
+          const transform = (x: number) => Promise.resolve(succeed(x.toString()));
 
           describe('when input is a success', () => {
             const input = succeed(2);
@@ -86,7 +86,7 @@ describe('andThrough', () => {
         });
 
         describe('when output is a failure', () => {
-          const transform = (x: number) => fail(Promise.resolve(x.toString()));
+          const transform = (x: number) => Promise.resolve(fail(x.toString()));
 
           describe('when input is a success', () => {
             const input = succeed(2);
@@ -117,22 +117,22 @@ describe('andThrough', () => {
           const transform = (x: number) => succeed(x.toString());
 
           describe('when input is a success', () => {
-            const input = succeed(Promise.resolve(2));
+            const input = Promise.resolve(succeed(2));
 
             it('should return a ResultAsync with original value', () => {
               const result = andThrough(transform)(input);
 
-              expectTypeOf(result).toEqualTypeOf<ResultAsync<number, never>>();
+              expectTypeOf(result).toEqualTypeOf<ResultAsync<2, never>>();
             });
           });
 
           describe('when input is a failure', () => {
-            const input = fail(Promise.resolve('error'));
+            const input = Promise.resolve(fail('error'));
 
             it('should return a ResultAsync with original error', () => {
               const result = andThrough(transform)(input);
 
-              expectTypeOf(result).toEqualTypeOf<ResultAsync<never, string>>();
+              expectTypeOf(result).toEqualTypeOf<ResultAsync<never, 'error'>>();
             });
           });
         });
@@ -141,17 +141,17 @@ describe('andThrough', () => {
           const transform = (x: number) => fail(x.toString());
 
           describe('when input is a success', () => {
-            const input = succeed(Promise.resolve(2));
+            const input = Promise.resolve(succeed(2));
 
             it('should return a ResultAsync with original value', () => {
               const result = andThrough(transform)(input);
 
-              expectTypeOf(result).toEqualTypeOf<ResultAsync<number, string>>();
+              expectTypeOf(result).toEqualTypeOf<ResultAsync<2, string>>();
             });
           });
 
           describe('when input is a failure', () => {
-            const input = fail(Promise.resolve('error'));
+            const input = Promise.resolve(fail('error'));
 
             it('should return a ResultAsync with original error', () => {
               const result = andThrough(transform)(input);
@@ -164,44 +164,44 @@ describe('andThrough', () => {
 
       describe('when output is asynchronous (Promise)', () => {
         describe('when output is a success', () => {
-          const transform = (x: number) => succeed(Promise.resolve(x.toString()));
+          const transform = (x: number) => Promise.resolve(succeed(x.toString()));
 
           describe('when input is a success', () => {
-            const input = succeed(Promise.resolve(2));
+            const input = Promise.resolve(succeed(2));
 
             it('should return a ResultAsync with original value', () => {
               const result = andThrough(transform)(input);
 
-              expectTypeOf(result).toEqualTypeOf<ResultAsync<number, never>>();
+              expectTypeOf(result).toEqualTypeOf<ResultAsync<2, never>>();
             });
           });
 
           describe('when input is a failure', () => {
-            const input = fail(Promise.resolve('error'));
+            const input = Promise.resolve(fail('error'));
 
             it('should return a ResultAsync with original error', () => {
               const result = andThrough(transform)(input);
 
-              expectTypeOf(result).toEqualTypeOf<ResultAsync<never, string>>();
+              expectTypeOf(result).toEqualTypeOf<ResultAsync<never, 'error'>>();
             });
           });
         });
 
         describe('when output is a failure', () => {
-          const transform = (x: number) => fail(Promise.resolve(x.toString()));
+          const transform = (x: number) => Promise.resolve(fail(x.toString()));
 
           describe('when input is a success', () => {
-            const input = succeed(Promise.resolve(2));
+            const input = Promise.resolve(succeed(2));
 
             it('should return a ResultAsync with original value', () => {
               const result = andThrough(transform)(input);
 
-              expectTypeOf(result).toEqualTypeOf<ResultAsync<number, string>>();
+              expectTypeOf(result).toEqualTypeOf<ResultAsync<2, string>>();
             });
           });
 
           describe('when input is a failure', () => {
-            const input = fail(Promise.resolve('error'));
+            const input = Promise.resolve(fail('error'));
 
             it('should return a ResultAsync with original error', () => {
               const result = andThrough(transform)(input);
@@ -282,7 +282,7 @@ describe('andThrough', () => {
             it('should return a ResultAsync with original value', () => {
               const result = pipe(
                 input,
-                andThrough((x) => succeed(Promise.resolve(x.toString()))),
+                andThrough((x) => Promise.resolve(succeed(x.toString()))),
               );
 
               expectTypeOf(result).toEqualTypeOf<ResultAsync<2, never>>();
@@ -295,7 +295,7 @@ describe('andThrough', () => {
             it('should return a ResultAsync with original error', () => {
               const result = pipe(
                 input,
-                andThrough((x) => succeed(Promise.resolve(x.toString()))),
+                andThrough((x) => Promise.resolve(succeed(x.toString()))),
               );
 
               expectTypeOf(result).toEqualTypeOf<ResultAsync<number, string>>();
@@ -310,7 +310,7 @@ describe('andThrough', () => {
             it('should return a ResultAsync with original value', () => {
               const result = pipe(
                 input,
-                andThrough((x) => fail(Promise.resolve(x.toString()))),
+                andThrough((x) => Promise.resolve(fail(x.toString()))),
               );
 
               expectTypeOf(result).toEqualTypeOf<ResultAsync<2, string>>();
@@ -323,7 +323,7 @@ describe('andThrough', () => {
             it('should return a ResultAsync with original error', () => {
               const result = pipe(
                 input,
-                andThrough((x) => fail(Promise.resolve(x.toString()))),
+                andThrough((x) => Promise.resolve(fail(x.toString()))),
               );
 
               expectTypeOf(result).toEqualTypeOf<ResultAsync<number, string>>();
@@ -337,7 +337,7 @@ describe('andThrough', () => {
       describe('when output is synchronous', () => {
         describe('when output is a success', () => {
           describe('when input is a success', () => {
-            const input = succeed(Promise.resolve(2));
+            const input = Promise.resolve(succeed(2));
 
             it('should return a ResultAsync with original value', () => {
               const result = pipe(
@@ -345,12 +345,12 @@ describe('andThrough', () => {
                 andThrough((x) => succeed(x.toString())),
               );
 
-              expectTypeOf(result).toEqualTypeOf<ResultAsync<number, never>>();
+              expectTypeOf(result).toEqualTypeOf<ResultAsync<2, never>>();
             });
           });
 
           describe('when input is a failure', () => {
-            const input: ResultAsync<number, string> = fail(Promise.resolve('error'));
+            const input: ResultAsync<number, string> = Promise.resolve(fail('error'));
 
             it('should return a ResultAsync with original error', () => {
               const result = pipe(
@@ -365,7 +365,7 @@ describe('andThrough', () => {
 
         describe('when output is a failure', () => {
           describe('when input is a success', () => {
-            const input = succeed(Promise.resolve(2));
+            const input = Promise.resolve(succeed(2));
 
             it('should return a ResultAsync with original value', () => {
               const result = pipe(
@@ -373,12 +373,12 @@ describe('andThrough', () => {
                 andThrough((x) => fail(x.toString())),
               );
 
-              expectTypeOf(result).toEqualTypeOf<ResultAsync<number, string>>();
+              expectTypeOf(result).toEqualTypeOf<ResultAsync<2, string>>();
             });
           });
 
           describe('when input is a failure', () => {
-            const input: ResultAsync<number, string> = fail(Promise.resolve('error'));
+            const input: ResultAsync<number, string> = Promise.resolve(fail('error'));
 
             it('should return a ResultAsync with original error', () => {
               const result = pipe(
@@ -395,25 +395,25 @@ describe('andThrough', () => {
       describe('when output is asynchronous (Promise)', () => {
         describe('when output is a success', () => {
           describe('when input is a success', () => {
-            const input = succeed(Promise.resolve(2));
+            const input = Promise.resolve(succeed(2));
 
             it('should return a ResultAsync with original value', () => {
               const result = pipe(
                 input,
-                andThrough((x) => succeed(Promise.resolve(x.toString()))),
+                andThrough((x) => Promise.resolve(succeed(x.toString()))),
               );
 
-              expectTypeOf(result).toEqualTypeOf<ResultAsync<number, never>>();
+              expectTypeOf(result).toEqualTypeOf<ResultAsync<2, never>>();
             });
           });
 
           describe('when input is a failure', () => {
-            const input: ResultAsync<number, string> = fail(Promise.resolve('error'));
+            const input: ResultAsync<number, string> = Promise.resolve(fail('error'));
 
             it('should return a ResultAsync with original error', () => {
               const result = pipe(
                 input,
-                andThrough((x) => succeed(Promise.resolve(x.toString()))),
+                andThrough((x) => Promise.resolve(succeed(x.toString()))),
               );
 
               expectTypeOf(result).toEqualTypeOf<ResultAsync<number, string>>();
@@ -423,25 +423,25 @@ describe('andThrough', () => {
 
         describe('when output is a failure', () => {
           describe('when input is a success', () => {
-            const input = succeed(Promise.resolve(2));
+            const input = Promise.resolve(succeed(2));
 
             it('should return a ResultAsync with original value', () => {
               const result = pipe(
                 input,
-                andThrough((x) => fail(Promise.resolve(x.toString()))),
+                andThrough((x) => Promise.resolve(fail(x.toString()))),
               );
 
-              expectTypeOf(result).toEqualTypeOf<ResultAsync<number, string>>();
+              expectTypeOf(result).toEqualTypeOf<ResultAsync<2, string>>();
             });
           });
 
           describe('when input is a failure', () => {
-            const input: ResultAsync<number, string> = fail(Promise.resolve('error'));
+            const input: ResultAsync<number, string> = Promise.resolve(fail('error'));
 
             it('should return a ResultAsync with original error', () => {
               const result = pipe(
                 input,
-                andThrough((x) => fail(Promise.resolve(x.toString()))),
+                andThrough((x) => Promise.resolve(fail(x.toString()))),
               );
 
               expectTypeOf(result).toEqualTypeOf<ResultAsync<number, string>>();

--- a/packages/byethrow/src/functions/and-through.test.ts
+++ b/packages/byethrow/src/functions/and-through.test.ts
@@ -82,7 +82,7 @@ describe('andThrough', () => {
 
     describe('when output is asynchronous (Promise)', () => {
       describe('when output is a success', () => {
-        const transform = vi.fn((x: number) => succeed(Promise.resolve(x.toString())));
+        const transform = vi.fn((x: number) => Promise.resolve(succeed(x.toString())));
 
         describe('when input is a success', () => {
           const input = succeed(2);
@@ -118,7 +118,7 @@ describe('andThrough', () => {
       });
 
       describe('when output is a failure', () => {
-        const transform = vi.fn((x: number) => fail(Promise.resolve(x.toString())));
+        const transform = vi.fn((x: number) => Promise.resolve(fail(x.toString())));
 
         describe('when input is a success', () => {
           const input = succeed(2);
@@ -161,7 +161,7 @@ describe('andThrough', () => {
         const transform = vi.fn((x: number) => succeed(x.toString()));
 
         describe('when input is a success', () => {
-          const input = succeed(Promise.resolve(2));
+          const input = Promise.resolve(succeed(2));
 
           it('should not apply the function to the input', async () => {
             const result = await andThrough(transform)(input);
@@ -177,7 +177,7 @@ describe('andThrough', () => {
         });
 
         describe('when input is a failure', () => {
-          const input = fail(Promise.resolve('error'));
+          const input = Promise.resolve(fail('error'));
 
           it('should return the same failure', async () => {
             const result = await andThrough(transform)(input);
@@ -197,7 +197,7 @@ describe('andThrough', () => {
         const transform = vi.fn((x: number) => fail(x.toString()));
 
         describe('when input is a success', () => {
-          const input = succeed(Promise.resolve(2));
+          const input = Promise.resolve(succeed(2));
 
           it('should not apply the function to the input', async () => {
             const result = await andThrough(transform)(input);
@@ -213,7 +213,7 @@ describe('andThrough', () => {
         });
 
         describe('when input is a failure', () => {
-          const input = fail(Promise.resolve('error'));
+          const input = Promise.resolve(fail('error'));
 
           it('should return the same failure', async () => {
             const result = await andThrough(transform)(input);
@@ -232,10 +232,10 @@ describe('andThrough', () => {
 
     describe('when output is asynchronous (Promise)', () => {
       describe('when output is a success', () => {
-        const transform = vi.fn((x: number) => succeed(Promise.resolve(x.toString())));
+        const transform = vi.fn((x: number) => Promise.resolve(succeed(x.toString())));
 
         describe('when input is a success', () => {
-          const input = succeed(Promise.resolve(2));
+          const input = Promise.resolve(succeed(2));
 
           it('should not apply the function to the input', async () => {
             const result = await andThrough(transform)(input);
@@ -251,7 +251,7 @@ describe('andThrough', () => {
         });
 
         describe('when input is a failure', () => {
-          const input = fail(Promise.resolve('error'));
+          const input = Promise.resolve(fail('error'));
 
           it('should return the same failure', async () => {
             const result = await andThrough(transform)(input);
@@ -268,10 +268,10 @@ describe('andThrough', () => {
       });
 
       describe('when output is a failure', () => {
-        const transform = vi.fn((x: number) => fail(Promise.resolve(x.toString())));
+        const transform = vi.fn((x: number) => Promise.resolve(fail(x.toString())));
 
         describe('when input is a success', () => {
-          const input = succeed(Promise.resolve(2));
+          const input = Promise.resolve(succeed(2));
 
           it('should not apply the function to the input', async () => {
             const result = await andThrough(transform)(input);
@@ -287,7 +287,7 @@ describe('andThrough', () => {
         });
 
         describe('when input is a failure', () => {
-          const input = fail(Promise.resolve('error'));
+          const input = Promise.resolve(fail('error'));
 
           it('should return the same failure', async () => {
             const result = await andThrough(transform)(input);

--- a/packages/byethrow/src/functions/assert-failure.test-d.ts
+++ b/packages/byethrow/src/functions/assert-failure.test-d.ts
@@ -33,17 +33,17 @@ describe('assertFailure', () => {
     describe('when input is asynchronous (Promise)', () => {
       describe('when input is a failure', () => {
         it('should infer failure type', () => {
-          const input = fail(Promise.resolve('error'));
+          const input = Promise.resolve(fail('error'));
           const result = assertFailure(input);
 
-          expectTypeOf(result).toEqualTypeOf<Promise<Failure<string>>>();
+          expectTypeOf(result).toEqualTypeOf<Promise<Failure<'error'>>>();
         });
       });
 
       describe('when input is a success', () => {
         // oxlint-disable-next-line vitest/expect-expect
         it('should cause a type error', () => {
-          const input = succeed(Promise.resolve('value'));
+          const input = Promise.resolve(succeed('value'));
 
           // @ts-expect-error
           assertFailure(input);
@@ -82,18 +82,18 @@ describe('assertFailure', () => {
       describe('when input is a failure', () => {
         it('should infer failure type', () => {
           const result = pipe(
-            fail(Promise.resolve('error')),
+            Promise.resolve(fail('error')),
             assertFailure,
           );
 
-          expectTypeOf(result).toEqualTypeOf<Promise<Failure<string>>>();
+          expectTypeOf(result).toEqualTypeOf<Promise<Failure<'error'>>>();
         });
       });
 
       describe('when input is a success', () => {
         it('should cause a type error', () => {
           const result = pipe(
-            succeed(Promise.resolve('value')),
+            Promise.resolve(succeed('value')),
             // @ts-expect-error
             assertFailure,
           );

--- a/packages/byethrow/src/functions/assert-failure.test.ts
+++ b/packages/byethrow/src/functions/assert-failure.test.ts
@@ -30,7 +30,7 @@ describe('assertFailure', () => {
   describe('when input is asynchronous (Promise)', () => {
     describe('when input is a failure', () => {
       it('should return the failure', async () => {
-        const input = fail(Promise.resolve('error'));
+        const input = Promise.resolve(fail('error'));
 
         const result = await assertFailure(input);
 
@@ -40,7 +40,7 @@ describe('assertFailure', () => {
 
     describe('when input is a success', () => {
       it('should throw an error', async () => {
-        const input = succeed(Promise.resolve('value')) as ResultAsync<never, string>;
+        const input = Promise.resolve(succeed('value')) as ResultAsync<never, string>;
 
         await expect(assertFailure(input)).rejects.toThrow('Expected a Failure result, but received a Success');
       });

--- a/packages/byethrow/src/functions/assert-success.test-d.ts
+++ b/packages/byethrow/src/functions/assert-success.test-d.ts
@@ -33,10 +33,10 @@ describe('assertSuccess', () => {
     describe('when input is asynchronous (Promise)', () => {
       describe('when input is a success', () => {
         it('should infer success type', () => {
-          const input = succeed(Promise.resolve('value'));
+          const input = Promise.resolve(succeed('value'));
           const result = assertSuccess(input);
 
-          expectTypeOf(result).toEqualTypeOf<Promise<Success<string>>>();
+          expectTypeOf(result).toEqualTypeOf<Promise<Success<'value'>>>();
         });
       });
 
@@ -82,11 +82,11 @@ describe('assertSuccess', () => {
       describe('when input is a success', () => {
         it('should infer success type', () => {
           const result = pipe(
-            succeed(Promise.resolve('value')),
+            Promise.resolve(succeed('value')),
             assertSuccess,
           );
 
-          expectTypeOf(result).toEqualTypeOf<Promise<Success<string>>>();
+          expectTypeOf(result).toEqualTypeOf<Promise<Success<'value'>>>();
         });
       });
 

--- a/packages/byethrow/src/functions/assert-success.test.ts
+++ b/packages/byethrow/src/functions/assert-success.test.ts
@@ -30,7 +30,7 @@ describe('assertSuccess', () => {
   describe('when input is asynchronous (Promise)', () => {
     describe('when input is a success', () => {
       it('should return the success', async () => {
-        const input = succeed(Promise.resolve('value'));
+        const input = Promise.resolve(succeed('value'));
 
         const result = await assertSuccess(input);
 
@@ -40,7 +40,7 @@ describe('assertSuccess', () => {
 
     describe('when input is a failure', () => {
       it('should throw an error', async () => {
-        const input = fail(Promise.resolve('error')) as ResultAsync<number, never>;
+        const input = Promise.resolve(fail('error')) as ResultAsync<number, never>;
 
         await expect(assertSuccess(input)).rejects.toThrow('Expected a Success result, but received a Failure');
       });

--- a/packages/byethrow/src/functions/bind.test-d.ts
+++ b/packages/byethrow/src/functions/bind.test-d.ts
@@ -69,7 +69,7 @@ describe('bind', () => {
         const input = succeed({ foo: 1 });
 
         describe('when output is a success', () => {
-          const output = (x: InferSuccess<typeof input>) => succeed(Promise.resolve(x.foo.toString()));
+          const output = (x: InferSuccess<typeof input>) => Promise.resolve(succeed(x.foo.toString()));
 
           it('should return a ResultAsync with success containing resolved value', () => {
             const result = bind('bar', output)(input);
@@ -85,7 +85,7 @@ describe('bind', () => {
         });
 
         describe('when output is a failure', () => {
-          const output = (x: InferSuccess<typeof input>) => fail(Promise.resolve(x.foo.toString()));
+          const output = (x: InferSuccess<typeof input>) => Promise.resolve(fail(x.foo.toString()));
 
           it('should return a ResultAsync with failure containing resolved error', () => {
             const result = bind('bar', output)(input);
@@ -104,7 +104,7 @@ describe('bind', () => {
 
     describe('when input is asynchronous (Promise)', () => {
       describe('when output is synchronous', () => {
-        const input = succeed(Promise.resolve({ foo: 1 }));
+        const input = Promise.resolve(succeed({ foo: 1 }));
 
         describe('when output is a success', () => {
           const output = (x: InferSuccess<typeof input>) => succeed(x.foo.toString());
@@ -112,7 +112,7 @@ describe('bind', () => {
           it('should return a ResultAsync with success when input and output resolve successfully', () => {
             const result = bind('bar', output)(input);
 
-            expectTypeOf(result).toEqualTypeOf<ResultAsync<{ foo: number; bar: string }, never>>();
+            expectTypeOf(result).toEqualTypeOf<ResultAsync<{ foo: 1; bar: string }, never>>();
           });
 
           it('should allow binding to an existing key, overwriting the value', () => {
@@ -128,7 +128,7 @@ describe('bind', () => {
           it('should return a ResultAsync with failure when output fails after input success', () => {
             const result = bind('bar', output)(input);
 
-            expectTypeOf(result).toEqualTypeOf<ResultAsync<{ foo: number; bar: never }, string>>();
+            expectTypeOf(result).toEqualTypeOf<ResultAsync<{ foo: 1; bar: never }, string>>();
           });
 
           it('should allow binding to an existing key, overwriting the value', () => {
@@ -139,7 +139,7 @@ describe('bind', () => {
         });
 
         describe('when input is a failure', () => {
-          const input: ResultAsync<{ foo: number }, string> = fail(Promise.resolve('error'));
+          const input: ResultAsync<{ foo: number }, string> = Promise.resolve(fail('error'));
           const output = (x: InferSuccess<typeof input>) => succeed(x.foo.toString());
 
           it('should propagate the async failure without invoking output function', () => {
@@ -157,15 +157,15 @@ describe('bind', () => {
       });
 
       describe('when output is asynchronous (Promise)', () => {
-        const input = succeed(Promise.resolve({ foo: 1 }));
+        const input = Promise.resolve(succeed({ foo: 1 }));
 
         describe('when output is a success', () => {
-          const output = (x: InferSuccess<typeof input>) => succeed(Promise.resolve(x.foo.toString()));
+          const output = (x: InferSuccess<typeof input>) => Promise.resolve(succeed(x.foo.toString()));
 
           it('should return a ResultAsync with nested resolved success values', () => {
             const result = bind('bar', output)(input);
 
-            expectTypeOf(result).toEqualTypeOf<ResultAsync<{ foo: number; bar: string }, never>>();
+            expectTypeOf(result).toEqualTypeOf<ResultAsync<{ foo: 1; bar: string }, never>>();
           });
 
           it('should allow binding to an existing key, overwriting the value', () => {
@@ -176,12 +176,12 @@ describe('bind', () => {
         });
 
         describe('when output is a failure', () => {
-          const output = (x: InferSuccess<typeof input>) => fail(Promise.resolve(x.foo.toString()));
+          const output = (x: InferSuccess<typeof input>) => Promise.resolve(fail(x.foo.toString()));
 
           it('should return a ResultAsync with nested resolved failure values', () => {
             const result = bind('bar', output)(input);
 
-            expectTypeOf(result).toEqualTypeOf<ResultAsync<{ foo: number; bar: never }, string>>();
+            expectTypeOf(result).toEqualTypeOf<ResultAsync<{ foo: 1; bar: never }, string>>();
           });
 
           it('should allow binding to an existing key, overwriting the value', () => {
@@ -271,7 +271,7 @@ describe('bind', () => {
           it('should return a ResultAsync with success containing resolved value', () => {
             const result = pipe(
               input,
-              bind('bar', (x) => succeed(Promise.resolve(x.foo.toString()))),
+              bind('bar', (x) => Promise.resolve(succeed(x.foo.toString()))),
             );
 
             expectTypeOf(result).toEqualTypeOf<ResultAsync<{ foo: 1; bar: string }, never>>();
@@ -280,7 +280,7 @@ describe('bind', () => {
           it('should allow binding to an existing key, overwriting the value', () => {
             const result = pipe(
               input,
-              bind('foo', (x) => succeed(Promise.resolve(x.foo.toString()))),
+              bind('foo', (x) => Promise.resolve(succeed(x.foo.toString()))),
             );
 
             expectTypeOf(result).toEqualTypeOf<ResultAsync<{ foo: string }, never>>();
@@ -291,7 +291,7 @@ describe('bind', () => {
           it('should return a ResultAsync with failure containing resolved error', () => {
             const result = pipe(
               input,
-              bind('bar', (x) => fail(Promise.resolve(x.foo.toString()))),
+              bind('bar', (x) => Promise.resolve(fail(x.foo.toString()))),
             );
 
             expectTypeOf(result).toEqualTypeOf<ResultAsync<{ foo: 1; bar: never }, string>>();
@@ -300,7 +300,7 @@ describe('bind', () => {
           it('should allow binding to an existing key, overwriting the value', () => {
             const result = pipe(
               input,
-              bind('foo', (x) => fail(Promise.resolve(x.foo.toString()))),
+              bind('foo', (x) => Promise.resolve(fail(x.foo.toString()))),
             );
 
             expectTypeOf(result).toEqualTypeOf<ResultAsync<{ foo: never }, string>>();
@@ -311,7 +311,7 @@ describe('bind', () => {
 
     describe('when input is asynchronous (Promise)', () => {
       describe('when output is synchronous', () => {
-        const input = succeed(Promise.resolve({ foo: 1 }));
+        const input = Promise.resolve(succeed({ foo: 1 }));
 
         describe('when output is a success', () => {
           it('should return a ResultAsync with success when input and output resolve successfully', () => {
@@ -320,7 +320,7 @@ describe('bind', () => {
               bind('bar', (x) => succeed(x.foo.toString())),
             );
 
-            expectTypeOf(result).toEqualTypeOf<ResultAsync<{ foo: number; bar: string }, never>>();
+            expectTypeOf(result).toEqualTypeOf<ResultAsync<{ foo: 1; bar: string }, never>>();
           });
 
           it('should allow binding to an existing key, overwriting the value', () => {
@@ -340,7 +340,7 @@ describe('bind', () => {
               bind('bar', (x) => fail(x.foo.toString())),
             );
 
-            expectTypeOf(result).toEqualTypeOf<ResultAsync<{ foo: number; bar: never }, string>>();
+            expectTypeOf(result).toEqualTypeOf<ResultAsync<{ foo: 1; bar: never }, string>>();
           });
 
           it('should allow binding to an existing key, overwriting the value', () => {
@@ -354,7 +354,7 @@ describe('bind', () => {
         });
 
         describe('when input is a failure', () => {
-          const input: ResultAsync<{ foo: number }, string> = fail(Promise.resolve('error'));
+          const input: ResultAsync<{ foo: number }, string> = Promise.resolve(fail('error'));
 
           it('should propagate the async failure without invoking output function', () => {
             const result = pipe(
@@ -377,22 +377,22 @@ describe('bind', () => {
       });
 
       describe('when output is asynchronous (Promise)', () => {
-        const input = succeed(Promise.resolve({ foo: 1 }));
+        const input = Promise.resolve(succeed({ foo: 1 }));
 
         describe('when output is a success', () => {
           it('should return a ResultAsync with nested resolved success values', () => {
             const result = pipe(
               input,
-              bind('bar', (x) => succeed(Promise.resolve(x.foo.toString()))),
+              bind('bar', (x) => Promise.resolve(succeed(x.foo.toString()))),
             );
 
-            expectTypeOf(result).toEqualTypeOf<ResultAsync<{ foo: number; bar: string }, never>>();
+            expectTypeOf(result).toEqualTypeOf<ResultAsync<{ foo: 1; bar: string }, never>>();
           });
 
           it('should allow binding to an existing key, overwriting the value', () => {
             const result = pipe(
               input,
-              bind('foo', (x) => succeed(Promise.resolve(x.foo.toString()))),
+              bind('foo', (x) => Promise.resolve(succeed(x.foo.toString()))),
             );
 
             expectTypeOf(result).toEqualTypeOf<ResultAsync<{ foo: string }, never>>();
@@ -403,16 +403,16 @@ describe('bind', () => {
           it('should return a ResultAsync with nested resolved failure values', () => {
             const result = pipe(
               input,
-              bind('bar', (x) => fail(Promise.resolve(x.foo.toString()))),
+              bind('bar', (x) => Promise.resolve(fail(x.foo.toString()))),
             );
 
-            expectTypeOf(result).toEqualTypeOf<ResultAsync<{ foo: number; bar: never }, string>>();
+            expectTypeOf(result).toEqualTypeOf<ResultAsync<{ foo: 1; bar: never }, string>>();
           });
 
           it('should allow binding to an existing key, overwriting the value', () => {
             const result = pipe(
               input,
-              bind('foo', (x) => fail(Promise.resolve(x.foo.toString()))),
+              bind('foo', (x) => Promise.resolve(fail(x.foo.toString()))),
             );
 
             expectTypeOf(result).toEqualTypeOf<ResultAsync<{ foo: never }, string>>();

--- a/packages/byethrow/src/functions/bind.test.ts
+++ b/packages/byethrow/src/functions/bind.test.ts
@@ -73,7 +73,7 @@ describe('bind', () => {
       const input = succeed({ foo: 1 });
 
       describe('when output is a success', () => {
-        const output = vi.fn((x: InferSuccess<typeof input>) => succeed(Promise.resolve(x.foo.toString())));
+        const output = vi.fn((x: InferSuccess<typeof input>) => Promise.resolve(succeed(x.foo.toString())));
 
         it('should merge the results', async () => {
           const result = await bind('bar', output)(input);
@@ -95,7 +95,7 @@ describe('bind', () => {
       });
 
       describe('when output is a failure', () => {
-        const output = vi.fn((x: InferSuccess<typeof input>) => fail(Promise.resolve(x.foo.toString())));
+        const output = vi.fn((x: InferSuccess<typeof input>) => Promise.resolve(fail(x.foo.toString())));
 
         it('should return the failure', async () => {
           const result = await bind('bar', output)(input);
@@ -114,7 +114,7 @@ describe('bind', () => {
 
   describe('when input is asynchronous (Promise)', () => {
     describe('when output is synchronous', () => {
-      const input = succeed(Promise.resolve({ foo: 1 }));
+      const input = Promise.resolve(succeed({ foo: 1 }));
 
       describe('when output is a success', () => {
         const output = vi.fn((x: InferSuccess<typeof input>) => succeed(x.foo.toString()));
@@ -155,7 +155,7 @@ describe('bind', () => {
       });
 
       describe('when input is a failure', () => {
-        const input: ResultAsync<{ foo: number }, string> = fail(Promise.resolve('error'));
+        const input: ResultAsync<{ foo: number }, string> = Promise.resolve(fail('error'));
         const output = vi.fn((x: InferSuccess<typeof input>) => succeed(x.foo.toString()));
 
         it('should return the failure', async () => {
@@ -173,10 +173,10 @@ describe('bind', () => {
     });
 
     describe('when output is asynchronous (Promise)', () => {
-      const input = succeed(Promise.resolve({ foo: 1 }));
+      const input = Promise.resolve(succeed({ foo: 1 }));
 
       describe('when output is a success', () => {
-        const output = vi.fn((x: InferSuccess<typeof input>) => succeed(Promise.resolve(x.foo.toString())));
+        const output = vi.fn((x: InferSuccess<typeof input>) => Promise.resolve(succeed(x.foo.toString())));
 
         it('should merge the results', async () => {
           const result = await bind('bar', output)(input);
@@ -198,7 +198,7 @@ describe('bind', () => {
       });
 
       describe('when output is a failure', () => {
-        const output = vi.fn((x: InferSuccess<typeof input>) => fail(Promise.resolve(x.foo.toString())));
+        const output = vi.fn((x: InferSuccess<typeof input>) => Promise.resolve(fail(x.foo.toString())));
 
         it('should return the failure', async () => {
           const result = await bind('bar', output)(input);

--- a/packages/byethrow/src/functions/collect.test-d.ts
+++ b/packages/byethrow/src/functions/collect.test-d.ts
@@ -31,20 +31,20 @@ describe('collect', () => {
     describe('when some Results are asynchronous', () => {
       it('should return a ResultAsync with object of values', () => {
         const result = collect({
-          name: succeed(Promise.resolve('Alice')),
+          name: Promise.resolve(succeed('Alice')),
           age: succeed(20),
         });
 
-        expectTypeOf(result).toEqualTypeOf<ResultAsync<{ name: string; age: 20 }, never[]>>();
+        expectTypeOf(result).toEqualTypeOf<ResultAsync<{ name: 'Alice'; age: 20 }, never[]>>();
       });
 
       it('should return a ResultAsync with error array when some fail', () => {
         const result = collect({
-          name: succeed(Promise.resolve('Alice')),
+          name: Promise.resolve(succeed('Alice')),
           age: fail('Invalid age'),
         });
 
-        expectTypeOf(result).toEqualTypeOf<ResultAsync<{ name: string; age: never }, 'Invalid age'[]>>();
+        expectTypeOf(result).toEqualTypeOf<ResultAsync<{ name: 'Alice'; age: never }, 'Invalid age'[]>>();
       });
     });
   });
@@ -75,22 +75,22 @@ describe('collect', () => {
     describe('when some Results are asynchronous', () => {
       it('should return a ResultAsync with array of values', () => {
         const result = collect([
-          succeed(Promise.resolve(1)),
+          Promise.resolve(succeed(1)),
           succeed(2),
           succeed(3),
         ]);
 
-        expectTypeOf(result).toEqualTypeOf<ResultAsync<[number, 2, 3], never[]>>();
+        expectTypeOf(result).toEqualTypeOf<ResultAsync<[1, 2, 3], never[]>>();
       });
 
       it('should return a ResultAsync with error array when some fail', () => {
         const result = collect([
-          succeed(Promise.resolve(1)),
+          Promise.resolve(succeed(1)),
           fail('error1'),
           fail('error2'),
         ]);
 
-        expectTypeOf(result).toEqualTypeOf<ResultAsync<[number, never, never], ('error1' | 'error2')[]>>();
+        expectTypeOf(result).toEqualTypeOf<ResultAsync<[1, never, never], ('error1' | 'error2')[]>>();
       });
     });
   });
@@ -112,13 +112,13 @@ describe('collect', () => {
 
     describe('when the mapping function returns asynchronous Results', () => {
       it('should return a ResultAsync with array of mapped values', () => {
-        const result = collect([1, 2, 3], (x) => succeed(Promise.resolve(x.toString())));
+        const result = collect([1, 2, 3], (x) => Promise.resolve(succeed(x.toString())));
 
         expectTypeOf(result).toEqualTypeOf<ResultAsync<[string, string, string], never[]>>();
       });
 
       it('should return a ResultAsync with error array when some fail', () => {
-        const result = collect([1, 2, 3], (x) => x > 1 ? fail(Promise.resolve(x.toString())) : succeed(Promise.resolve(x.toString())));
+        const result = collect([1, 2, 3], (x) => x > 1 ? Promise.resolve(fail(x.toString())) : Promise.resolve(succeed(x.toString())));
 
         expectTypeOf(result).toEqualTypeOf<ResultAsync<[string, string, string], string[]>>();
       });

--- a/packages/byethrow/src/functions/collect.test.ts
+++ b/packages/byethrow/src/functions/collect.test.ts
@@ -53,9 +53,9 @@ describe('collect', () => {
     describe('when some Results are asynchronous', () => {
       it('should handle async successful results', async () => {
         const result = await collect({
-          a: succeed(Promise.resolve(1)),
-          b: succeed(Promise.resolve('hello')),
-          c: succeed(Promise.resolve(true)),
+          a: Promise.resolve(succeed(1)),
+          b: Promise.resolve(succeed('hello')),
+          c: Promise.resolve(succeed(true)),
         });
 
         expect(result).toEqual(succeed({ a: 1, b: 'hello', c: true }));
@@ -64,7 +64,7 @@ describe('collect', () => {
       it('should handle mixed sync and async successful results', async () => {
         const result = await collect({
           a: succeed(1),
-          b: succeed(Promise.resolve('hello')),
+          b: Promise.resolve(succeed('hello')),
           c: succeed(true),
         });
 
@@ -73,9 +73,9 @@ describe('collect', () => {
 
       it('should handle async failures', async () => {
         const result = await collect({
-          a: succeed(Promise.resolve(1)),
-          b: fail(Promise.resolve('error1')),
-          c: fail(Promise.resolve('error2')),
+          a: Promise.resolve(succeed(1)),
+          b: Promise.resolve(fail('error1')),
+          c: Promise.resolve(fail('error2')),
         });
 
         expect(result).toEqual(fail(['error1', 'error2']));
@@ -131,9 +131,9 @@ describe('collect', () => {
     describe('when some Results are asynchronous', () => {
       it('should handle async successful results', async () => {
         const result = await collect([
-          succeed(Promise.resolve(1)),
-          succeed(Promise.resolve(2)),
-          succeed(Promise.resolve(3)),
+          Promise.resolve(succeed(1)),
+          Promise.resolve(succeed(2)),
+          Promise.resolve(succeed(3)),
         ]);
 
         expect(result).toEqual(succeed([1, 2, 3]));
@@ -142,7 +142,7 @@ describe('collect', () => {
       it('should handle mixed sync and async successful results', async () => {
         const result = await collect([
           succeed(1),
-          succeed(Promise.resolve(2)),
+          Promise.resolve(succeed(2)),
           succeed(3),
         ]);
 
@@ -151,9 +151,9 @@ describe('collect', () => {
 
       it('should handle async failures', async () => {
         const result = await collect([
-          succeed(Promise.resolve(1)),
-          fail(Promise.resolve('error1')),
-          fail(Promise.resolve('error2')),
+          Promise.resolve(succeed(1)),
+          Promise.resolve(fail('error1')),
+          Promise.resolve(fail('error2')),
         ]);
 
         expect(result).toEqual(fail(['error1', 'error2']));
@@ -193,8 +193,8 @@ describe('collect', () => {
         const result = await collect(['1', '2', '3'], (value) => {
           const number = Number(value);
           return Number.isNaN(number)
-            ? fail(Promise.resolve(`Invalid number: ${value}`))
-            : succeed(Promise.resolve(number));
+            ? Promise.resolve(fail(`Invalid number: ${value}`))
+            : Promise.resolve(succeed(number));
         });
 
         expect(result).toEqual(succeed([1, 2, 3]));
@@ -204,8 +204,8 @@ describe('collect', () => {
         const result = await collect(['1', 'invalid', '3'], (value) => {
           const number = Number(value);
           return Number.isNaN(number)
-            ? fail(Promise.resolve(`Invalid number: ${value}`))
-            : succeed(Promise.resolve(number));
+            ? Promise.resolve(fail(`Invalid number: ${value}`))
+            : Promise.resolve(succeed(number));
         });
 
         expect(result).toEqual(fail(['Invalid number: invalid']));

--- a/packages/byethrow/src/functions/fail.test-d.ts
+++ b/packages/byethrow/src/functions/fail.test-d.ts
@@ -2,7 +2,7 @@ import { describe, expectTypeOf, it } from 'vitest';
 
 import { fail } from './fail';
 
-import type { Result, ResultAsync } from '../result';
+import type { Result } from '../result';
 
 describe('fail', () => {
   it('should return a Result when given a plain error', () => {
@@ -11,11 +11,10 @@ describe('fail', () => {
     expectTypeOf(result).toEqualTypeOf<Result<never, 'error'>>();
   });
 
-  it('should return a ResultAsync when given a Promise of error', () => {
-    const error = Promise.resolve('error' as const);
-    const result = fail(error);
+  it('should return a Result when given a Promise error', () => {
+    const result = fail(Promise.resolve('error'));
 
-    expectTypeOf(result).toEqualTypeOf<ResultAsync<never, 'error'>>();
+    expectTypeOf(result).toEqualTypeOf<Result<never, Promise<string>>>();
   });
 
   it('should return a Result with a no value', () => {

--- a/packages/byethrow/src/functions/fail.test.ts
+++ b/packages/byethrow/src/functions/fail.test.ts
@@ -13,13 +13,12 @@ describe('fail', () => {
     });
   });
 
-  it('should create a Failure object with a Promise error', async () => {
-    const error = Promise.resolve(new Error('Test promise error'));
-    const result = await fail(error);
+  it('should return a Result when a Promise is passed', () => {
+    const result = fail(Promise.resolve(42));
 
     expect(result).toEqual({
       type: 'Failure',
-      error: new Error('Test promise error'),
+      error: Promise.resolve(42),
     });
   });
 

--- a/packages/byethrow/src/functions/fail.ts
+++ b/packages/byethrow/src/functions/fail.ts
@@ -1,16 +1,15 @@
-/* oxlint-disable @typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-return,@typescript-eslint/no-unsafe-assignment */
+/* oxlint-disable @typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-assignment */
 
-import { isPromise } from '../internals/helpers/is-promise';
-
-import type { ResultFor } from '../result';
+import type { Result } from '../result';
 
 /**
  * Creates a {@link Failure} result from a given error.
- * Automatically wraps the error in a `Promise` if it is asynchronous.
+ *
+ * Passing a `Promise` is allowed, but it is recommended to `await` it before passing to `fail`.
  *
  * @function
  * @typeParam E - The type of the error to wrap.
- * @returns A {@link Result} or {@link ResultAsync} depending on whether the input is a promise.
+ * @returns A {@link Result} containing the given error.
  *
  * @example Synchronous Usage
  * ```ts
@@ -18,14 +17,6 @@ import type { ResultFor } from '../result';
  *
  * const result = Result.fail('Something went wrong');
  * // Result.Result<never, string>
- * ```
- *
- * @example Asynchronous Usage
- * ```ts
- * import { Result } from '@praha/byethrow';
- *
- * const result = Result.fail(Promise.resolve('Async error'));
- * // Result.ResultAsync<never, string>
  * ```
  *
  * @example With No Value
@@ -37,20 +28,18 @@ import type { ResultFor } from '../result';
  * ```
  *
  * @see {@link collect} - For collect multiple Results into a single Result.
+ * @see {@link sequence} - For sequence multiple Results into a single Result.
  *
  * @category Creators
  */
 export const fail: {
-  (): ResultFor<never, never, void>;
-  <const E>(error: E): ResultFor<E, never, Awaited<E>>;
-} = (...args: any[]) => {
+  (): Result<never, void>;
+  <const E>(error: E): Result<never, E>;
+} = ((...args: any[]) => {
   if (args.length <= 0) {
     return { type: 'Failure', error: undefined };
   }
 
   const error = args[0];
-  if (isPromise(error)) {
-    return error.then((error) => ({ type: 'Failure', error: error }));
-  }
-  return { type: 'Failure', error } as any;
-};
+  return { type: 'Failure', error };
+}) as any;

--- a/packages/byethrow/src/functions/fn.ts
+++ b/packages/byethrow/src/functions/fn.ts
@@ -89,9 +89,9 @@ const fn: {
       // oxlint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const output = options.try(...args);
       if (isPromise(output)) {
-        const promise = succeed(output);
+        const promise = output.then((value: any) => succeed(value));
         if ('safe' in options && options.safe) return promise;
-        return promise.catch((error) => fail(options.catch(error)));
+        return promise.catch((error: any) => fail(options.catch(error)));
       }
 
       return succeed(output);

--- a/packages/byethrow/src/functions/inspect-error.test-d.ts
+++ b/packages/byethrow/src/functions/inspect-error.test-d.ts
@@ -64,22 +64,22 @@ describe('inspectError', () => {
         const sideEffect = (x: string) => x;
 
         describe('when input is a failure', () => {
-          const input = fail(Promise.resolve('error'));
+          const input = Promise.resolve(fail('error'));
 
           it('should preserve the original result type', () => {
             const result = inspectError(sideEffect)(input);
 
-            expectTypeOf(result).toEqualTypeOf<ResultAsync<never, string>>();
+            expectTypeOf(result).toEqualTypeOf<ResultAsync<never, 'error'>>();
           });
         });
 
         describe('when input is a success', () => {
-          const input = succeed(Promise.resolve(42));
+          const input = Promise.resolve(succeed(42));
 
           it('should preserve the original result type', () => {
             const result = inspectError(sideEffect)(input);
 
-            expectTypeOf(result).toEqualTypeOf<ResultAsync<number, never>>();
+            expectTypeOf(result).toEqualTypeOf<ResultAsync<42, never>>();
           });
         });
       });
@@ -88,22 +88,22 @@ describe('inspectError', () => {
         const sideEffect = (x: string) => Promise.resolve(x);
 
         describe('when input is a failure', () => {
-          const input = fail(Promise.resolve('error'));
+          const input = Promise.resolve(fail('error'));
 
           it('should preserve the original result type', () => {
             const result = inspectError(sideEffect)(input);
 
-            expectTypeOf(result).toEqualTypeOf<ResultAsync<never, string>>();
+            expectTypeOf(result).toEqualTypeOf<ResultAsync<never, 'error'>>();
           });
         });
 
         describe('when input is a success', () => {
-          const input = succeed(Promise.resolve(42));
+          const input = Promise.resolve(succeed(42));
 
           it('should preserve the original result type', () => {
             const result = inspectError(sideEffect)(input);
 
-            expectTypeOf(result).toEqualTypeOf<ResultAsync<number, never>>();
+            expectTypeOf(result).toEqualTypeOf<ResultAsync<42, never>>();
           });
         });
       });
@@ -172,7 +172,7 @@ describe('inspectError', () => {
     describe('when input is asynchronous (Promise)', () => {
       describe('when output is synchronous', () => {
         describe('when input is a failure', () => {
-          const input = fail(Promise.resolve('error'));
+          const input = Promise.resolve(fail('error'));
 
           it('should preserve the original result type', () => {
             const result = pipe(
@@ -180,12 +180,12 @@ describe('inspectError', () => {
               inspectError((x) => x.length),
             );
 
-            expectTypeOf(result).toEqualTypeOf<ResultAsync<never, string>>();
+            expectTypeOf(result).toEqualTypeOf<ResultAsync<never, 'error'>>();
           });
         });
 
         describe('when input is a success', () => {
-          const input = succeed(Promise.resolve(42));
+          const input = Promise.resolve(succeed(42));
 
           it('should preserve the original result type', () => {
             const result = pipe(
@@ -193,14 +193,14 @@ describe('inspectError', () => {
               inspectError((x: string) => x.length),
             );
 
-            expectTypeOf(result).toEqualTypeOf<ResultAsync<number, never>>();
+            expectTypeOf(result).toEqualTypeOf<ResultAsync<42, never>>();
           });
         });
       });
 
       describe('when output is asynchronous (Promise)', () => {
         describe('when input is a failure', () => {
-          const input = fail(Promise.resolve('error'));
+          const input = Promise.resolve(fail('error'));
 
           it('should preserve the original result type', () => {
             const result = pipe(
@@ -208,12 +208,12 @@ describe('inspectError', () => {
               inspectError((x) => Promise.resolve(x.length)),
             );
 
-            expectTypeOf(result).toEqualTypeOf<ResultAsync<never, string>>();
+            expectTypeOf(result).toEqualTypeOf<ResultAsync<never, 'error'>>();
           });
         });
 
         describe('when input is a success', () => {
-          const input = succeed(Promise.resolve(42));
+          const input = Promise.resolve(succeed(42));
 
           it('should preserve the original result type', () => {
             const result = pipe(
@@ -221,7 +221,7 @@ describe('inspectError', () => {
               inspectError((x: string) => Promise.resolve(x.length)),
             );
 
-            expectTypeOf(result).toEqualTypeOf<ResultAsync<number, never>>();
+            expectTypeOf(result).toEqualTypeOf<ResultAsync<42, never>>();
           });
         });
       });

--- a/packages/byethrow/src/functions/inspect-error.test.ts
+++ b/packages/byethrow/src/functions/inspect-error.test.ts
@@ -86,7 +86,7 @@ describe('inspectError', () => {
       const sideEffect = vi.fn((x: string) => x);
 
       describe('when input is a failure', () => {
-        const input = fail(Promise.resolve('async error'));
+        const input = Promise.resolve(fail('async error'));
 
         it('should return the original failure result unchanged', async () => {
           const result = await inspectError(sideEffect)(input);
@@ -103,7 +103,7 @@ describe('inspectError', () => {
       });
 
       describe('when input is a success', () => {
-        const input = succeed(Promise.resolve(42));
+        const input = Promise.resolve(succeed(42));
 
         it('should return the original success result unchanged', async () => {
           const result = await inspectError(sideEffect)(input);
@@ -123,7 +123,7 @@ describe('inspectError', () => {
       const sideEffect = vi.fn((x: string) => Promise.resolve(x));
 
       describe('when input is a failure', () => {
-        const input = fail(Promise.resolve('async error'));
+        const input = Promise.resolve(fail('async error'));
 
         it('should return the original failure result unchanged', async () => {
           const result = await inspectError(sideEffect)(input);
@@ -140,7 +140,7 @@ describe('inspectError', () => {
       });
 
       describe('when input is a success', () => {
-        const input = succeed(Promise.resolve(42));
+        const input = Promise.resolve(succeed(42));
 
         it('should return the original success result unchanged', async () => {
           const result = await inspectError(sideEffect)(input);

--- a/packages/byethrow/src/functions/inspect.test-d.ts
+++ b/packages/byethrow/src/functions/inspect.test-d.ts
@@ -64,22 +64,22 @@ describe('inspect', () => {
         const sideEffect = (x: number) => x;
 
         describe('when input is a success', () => {
-          const input = succeed(Promise.resolve(42));
+          const input = Promise.resolve(succeed(42));
 
           it('should preserve the original ResultAsync type', () => {
             const result = inspect(sideEffect)(input);
 
-            expectTypeOf(result).toEqualTypeOf<ResultAsync<number, never>>();
+            expectTypeOf(result).toEqualTypeOf<ResultAsync<42, never>>();
           });
         });
 
         describe('when input is a failure', () => {
-          const input = fail(Promise.resolve('error'));
+          const input = Promise.resolve(fail('error'));
 
           it('should preserve the original ResultAsync type', () => {
             const result = inspect(sideEffect)(input);
 
-            expectTypeOf(result).toEqualTypeOf<ResultAsync<never, string>>();
+            expectTypeOf(result).toEqualTypeOf<ResultAsync<never, 'error'>>();
           });
         });
       });
@@ -88,22 +88,22 @@ describe('inspect', () => {
         const sideEffect = (x: number) => Promise.resolve(x);
 
         describe('when input is a success', () => {
-          const input = succeed(Promise.resolve(42));
+          const input = Promise.resolve(succeed(42));
 
           it('should preserve the original ResultAsync type', () => {
             const result = inspect(sideEffect)(input);
 
-            expectTypeOf(result).toEqualTypeOf<ResultAsync<number, never>>();
+            expectTypeOf(result).toEqualTypeOf<ResultAsync<42, never>>();
           });
         });
 
         describe('when input is a failure', () => {
-          const input = fail(Promise.resolve('error'));
+          const input = Promise.resolve(fail('error'));
 
           it('should preserve the original ResultAsync type', () => {
             const result = inspect(sideEffect)(input);
 
-            expectTypeOf(result).toEqualTypeOf<ResultAsync<never, string>>();
+            expectTypeOf(result).toEqualTypeOf<ResultAsync<never, 'error'>>();
           });
         });
       });
@@ -172,7 +172,7 @@ describe('inspect', () => {
     describe('when input is asynchronous (Promise)', () => {
       describe('when output is synchronous', () => {
         describe('when input is a success', () => {
-          const input = succeed(Promise.resolve(42));
+          const input = Promise.resolve(succeed(42));
 
           it('should preserve the original ResultAsync type', () => {
             const result = pipe(
@@ -180,12 +180,12 @@ describe('inspect', () => {
               inspect((x) => x),
             );
 
-            expectTypeOf(result).toEqualTypeOf<ResultAsync<number, never>>();
+            expectTypeOf(result).toEqualTypeOf<ResultAsync<42, never>>();
           });
         });
 
         describe('when input is a failure', () => {
-          const input = fail(Promise.resolve('error'));
+          const input = Promise.resolve(fail('error'));
 
           it('should preserve the original ResultAsync type', () => {
             const result = pipe(
@@ -193,14 +193,14 @@ describe('inspect', () => {
               inspect((x) => x),
             );
 
-            expectTypeOf(result).toEqualTypeOf<ResultAsync<never, string>>();
+            expectTypeOf(result).toEqualTypeOf<ResultAsync<never, 'error'>>();
           });
         });
       });
 
       describe('when output is asynchronous (Promise)', () => {
         describe('when input is a success', () => {
-          const input = succeed(Promise.resolve(42));
+          const input = Promise.resolve(succeed(42));
 
           it('should preserve the original ResultAsync type', () => {
             const result = pipe(
@@ -208,12 +208,12 @@ describe('inspect', () => {
               inspect((x) => Promise.resolve(x)),
             );
 
-            expectTypeOf(result).toEqualTypeOf<ResultAsync<number, never>>();
+            expectTypeOf(result).toEqualTypeOf<ResultAsync<42, never>>();
           });
         });
 
         describe('when input is a failure', () => {
-          const input = fail(Promise.resolve('error'));
+          const input = Promise.resolve(fail('error'));
 
           it('should preserve the original ResultAsync type', () => {
             const result = pipe(
@@ -221,7 +221,7 @@ describe('inspect', () => {
               inspect((x: number) => Promise.resolve(x)),
             );
 
-            expectTypeOf(result).toEqualTypeOf<ResultAsync<never, string>>();
+            expectTypeOf(result).toEqualTypeOf<ResultAsync<never, 'error'>>();
           });
         });
       });

--- a/packages/byethrow/src/functions/inspect.test.ts
+++ b/packages/byethrow/src/functions/inspect.test.ts
@@ -86,7 +86,7 @@ describe('inspect', () => {
       const sideEffect = vi.fn((x: number) => x);
 
       describe('when input is a success', () => {
-        const input = succeed(Promise.resolve(42));
+        const input = Promise.resolve(succeed(42));
 
         it('should return the original success result unchanged', async () => {
           const result = await inspect(sideEffect)(input);
@@ -103,7 +103,7 @@ describe('inspect', () => {
       });
 
       describe('when input is a failure', () => {
-        const input = fail(Promise.resolve('async error'));
+        const input = Promise.resolve(fail('async error'));
 
         it('should return the original failure result unchanged', async () => {
           const result = await inspect(sideEffect)(input);
@@ -123,7 +123,7 @@ describe('inspect', () => {
       const sideEffect = vi.fn((x: number) => Promise.resolve(x));
 
       describe('when input is a success', () => {
-        const input = succeed(Promise.resolve(42));
+        const input = Promise.resolve(succeed(42));
 
         it('should return the original success result unchanged', async () => {
           const result = await inspect(sideEffect)(input);
@@ -140,7 +140,7 @@ describe('inspect', () => {
       });
 
       describe('when input is a failure', () => {
-        const input = fail(Promise.resolve('async error'));
+        const input = Promise.resolve(fail('async error'));
 
         it('should return the original failure result unchanged', async () => {
           const result = await inspect(sideEffect)(input);

--- a/packages/byethrow/src/functions/map-error.test-d.ts
+++ b/packages/byethrow/src/functions/map-error.test-d.ts
@@ -21,7 +21,7 @@ describe('mapError', () => {
 
     describe('when Result is asynchronous (Promise)', () => {
       it('should transform the error type in an asynchronous ResultAsync', () => {
-        const input = fail(Promise.resolve('error'));
+        const input = Promise.resolve(fail('error'));
         const result = mapError(transform)(input);
 
         expectTypeOf(result).toEqualTypeOf<ResultAsync<never, number>>();
@@ -44,7 +44,7 @@ describe('mapError', () => {
 
     describe('when Result is asynchronous (Promise)', () => {
       it('should transform the error type in an asynchronous ResultAsync', () => {
-        const input = fail(Promise.resolve('error'));
+        const input = Promise.resolve(fail('error'));
         const result = pipe(
           input,
           mapError((x) => x.length),

--- a/packages/byethrow/src/functions/map-error.test.ts
+++ b/packages/byethrow/src/functions/map-error.test.ts
@@ -43,7 +43,7 @@ describe('mapError', () => {
 
   describe('when Result is asynchronous (Promise)', () => {
     describe('when Result is a failure', () => {
-      const input = fail(Promise.resolve('error'));
+      const input = Promise.resolve(fail('error'));
 
       it('should apply the function to the input', async () => {
         const result = await mapError(transform)(input);
@@ -59,7 +59,7 @@ describe('mapError', () => {
     });
 
     describe('when Result is a success', () => {
-      const input = succeed(Promise.resolve(2));
+      const input = Promise.resolve(succeed(2));
 
       it('should return the same success', async () => {
         const result = await mapError(transform)(input);

--- a/packages/byethrow/src/functions/map.test-d.ts
+++ b/packages/byethrow/src/functions/map.test-d.ts
@@ -21,7 +21,7 @@ describe('map', () => {
 
     describe('when Result is asynchronous (Promise)', () => {
       it('should transform the value type in an asynchronous ResultAsync', () => {
-        const input = succeed(Promise.resolve(2));
+        const input = Promise.resolve(succeed(2));
         const result = map(transform)(input);
 
         expectTypeOf(result).toEqualTypeOf<ResultAsync<string, never>>();
@@ -44,7 +44,7 @@ describe('map', () => {
 
     describe('when Result is asynchronous (Promise)', () => {
       it('should transform the value type in an asynchronous ResultAsync', () => {
-        const input = succeed(Promise.resolve(2));
+        const input = Promise.resolve(succeed(2));
         const result = pipe(
           input,
           map((x) => x.toString()),

--- a/packages/byethrow/src/functions/map.test.ts
+++ b/packages/byethrow/src/functions/map.test.ts
@@ -43,7 +43,7 @@ describe('map', () => {
 
   describe('when input is asynchronous (Promise)', () => {
     describe('when input is a success', () => {
-      const input = succeed(Promise.resolve(2));
+      const input = Promise.resolve(succeed(2));
 
       it('should apply the function to the input', async () => {
         const result = await map(transform)(input);
@@ -59,7 +59,7 @@ describe('map', () => {
     });
 
     describe('when input is a failure', () => {
-      const input = fail(Promise.resolve('error'));
+      const input = Promise.resolve(fail('error'));
 
       it('should return the same failure', async () => {
         const result = await map(transform)(input);

--- a/packages/byethrow/src/functions/or-else.test-d.ts
+++ b/packages/byethrow/src/functions/or-else.test-d.ts
@@ -50,7 +50,7 @@ describe('orElse', () => {
       describe('when output is asynchronous (Promise)', () => {
         describe('when input is a success', () => {
           const input = succeed(42);
-          const transform = (x: string) => succeed(Promise.resolve(x.toUpperCase()));
+          const transform = (x: string) => Promise.resolve(succeed(x.toUpperCase()));
 
           it('should return a ResultAsync with original value', () => {
             const result = orElse(transform)(input);
@@ -63,7 +63,7 @@ describe('orElse', () => {
           const input = fail('error');
 
           describe('when input is a success', () => {
-            const transform = (x: string) => succeed(Promise.resolve(x.toUpperCase()));
+            const transform = (x: string) => Promise.resolve(succeed(x.toUpperCase()));
 
             it('should return a ResultAsync with transformed value', () => {
               const result = orElse(transform)(input);
@@ -73,7 +73,7 @@ describe('orElse', () => {
           });
 
           describe('when input is a failure', () => {
-            const transform = (x: string) => fail(Promise.resolve(x.toUpperCase()));
+            const transform = (x: string) => Promise.resolve(fail(x.toUpperCase()));
 
             it('should return a ResultAsync with transformed value', () => {
               const result = orElse(transform)(input);
@@ -88,18 +88,18 @@ describe('orElse', () => {
     describe('when input is asynchronous (Promise)', () => {
       describe('when output is synchronous', () => {
         describe('when input is a success', () => {
-          const input = succeed(Promise.resolve(42));
+          const input = Promise.resolve(succeed(42));
           const transform = (x: string) => succeed(x.toUpperCase());
 
           it('should return a ResultAsync with original value', () => {
             const result = orElse(transform)(input);
 
-            expectTypeOf(result).toEqualTypeOf<ResultAsync<number | string, never>>();
+            expectTypeOf(result).toEqualTypeOf<ResultAsync<42 | string, never>>();
           });
         });
 
         describe('when input is a failure', () => {
-          const input = fail(Promise.resolve('error'));
+          const input = Promise.resolve(fail('error'));
 
           describe('when input is a success', () => {
             const transform = (x: string) => succeed(x.toUpperCase());
@@ -125,21 +125,21 @@ describe('orElse', () => {
 
       describe('when output is asynchronous (Promise)', () => {
         describe('when input is a success', () => {
-          const input = succeed(Promise.resolve(42));
-          const transform = (x: string) => succeed(Promise.resolve(x.toUpperCase()));
+          const input = Promise.resolve(succeed(42));
+          const transform = (x: string) => Promise.resolve(succeed(x.toUpperCase()));
 
           it('should return a ResultAsync with original value', () => {
             const result = orElse(transform)(input);
 
-            expectTypeOf(result).toEqualTypeOf<ResultAsync<number | string, never>>();
+            expectTypeOf(result).toEqualTypeOf<ResultAsync<42 | string, never>>();
           });
         });
 
         describe('when input is a failure', () => {
-          const input = fail(Promise.resolve('error'));
+          const input = Promise.resolve(fail('error'));
 
           describe('when input is a success', () => {
-            const transform = (x: string) => succeed(Promise.resolve(x.toUpperCase()));
+            const transform = (x: string) => Promise.resolve(succeed(x.toUpperCase()));
 
             it('should return a ResultAsync with transformed value', () => {
               const result = orElse(transform)(input);
@@ -149,7 +149,7 @@ describe('orElse', () => {
           });
 
           describe('when input is a failure', () => {
-            const transform = (x: string) => fail(Promise.resolve(x.toUpperCase()));
+            const transform = (x: string) => Promise.resolve(fail(x.toUpperCase()));
 
             it('should return a ResultAsync with transformed value', () => {
               const result = orElse(transform)(input);
@@ -212,7 +212,7 @@ describe('orElse', () => {
           it('should return a ResultAsync with original value', () => {
             const result = pipe(
               input,
-              orElse((x: string) => succeed(Promise.resolve(x.toUpperCase()))),
+              orElse((x: string) => Promise.resolve(succeed(x.toUpperCase()))),
             );
 
             expectTypeOf(result).toEqualTypeOf<ResultAsync<42 | string, never>>();
@@ -226,7 +226,7 @@ describe('orElse', () => {
             it('should return a ResultAsync with transformed value', () => {
               const result = pipe(
                 input,
-                orElse((x) => succeed(Promise.resolve(x.toUpperCase()))),
+                orElse((x) => Promise.resolve(succeed(x.toUpperCase()))),
               );
 
               expectTypeOf(result).toEqualTypeOf<ResultAsync<number | string, never>>();
@@ -237,7 +237,7 @@ describe('orElse', () => {
             it('should return a ResultAsync with transformed value', () => {
               const result = pipe(
                 input,
-                orElse((x) => fail(Promise.resolve(x.toUpperCase()))),
+                orElse((x) => Promise.resolve(fail(x.toUpperCase()))),
               );
 
               expectTypeOf(result).toEqualTypeOf<ResultAsync<number, string>>();
@@ -250,7 +250,7 @@ describe('orElse', () => {
     describe('when input is asynchronous (Promise)', () => {
       describe('when output is synchronous', () => {
         describe('when input is a success', () => {
-          const input: ResultAsync<number, string> = succeed(Promise.resolve(42));
+          const input: ResultAsync<number, string> = Promise.resolve(succeed(42));
 
           it('should return a ResultAsync with original value', () => {
             const result = pipe(
@@ -263,7 +263,7 @@ describe('orElse', () => {
         });
 
         describe('when input is a failure', () => {
-          const input: ResultAsync<number, string> = fail(Promise.resolve('error'));
+          const input: ResultAsync<number, string> = Promise.resolve(fail('error'));
 
           describe('when input is a success', () => {
             it('should return a ResultAsync with transformed value', () => {
@@ -291,12 +291,12 @@ describe('orElse', () => {
 
       describe('when output is asynchronous (Promise)', () => {
         describe('when input is a success', () => {
-          const input: ResultAsync<number, string> = succeed(Promise.resolve(42));
+          const input: ResultAsync<number, string> = Promise.resolve(succeed(42));
 
           it('should return a ResultAsync with original value', () => {
             const result = pipe(
               input,
-              orElse((x: string) => succeed(Promise.resolve(x.toUpperCase()))),
+              orElse((x: string) => Promise.resolve(succeed(x.toUpperCase()))),
             );
 
             expectTypeOf(result).toEqualTypeOf<ResultAsync<number | string, never>>();
@@ -304,13 +304,13 @@ describe('orElse', () => {
         });
 
         describe('when input is a failure', () => {
-          const input: ResultAsync<number, string> = fail(Promise.resolve('error'));
+          const input: ResultAsync<number, string> = Promise.resolve(fail('error'));
 
           describe('when input is a success', () => {
             it('should return a ResultAsync with transformed value', () => {
               const result = pipe(
                 input,
-                orElse((x) => succeed(Promise.resolve(x.toUpperCase()))),
+                orElse((x) => Promise.resolve(succeed(x.toUpperCase()))),
               );
 
               expectTypeOf(result).toEqualTypeOf<ResultAsync<number | string, never>>();
@@ -321,7 +321,7 @@ describe('orElse', () => {
             it('should return a ResultAsync with transformed value', () => {
               const result = pipe(
                 input,
-                orElse((x) => fail(Promise.resolve(x.toUpperCase()))),
+                orElse((x) => Promise.resolve(fail(x.toUpperCase()))),
               );
 
               expectTypeOf(result).toEqualTypeOf<ResultAsync<number, string>>();

--- a/packages/byethrow/src/functions/or-else.test.ts
+++ b/packages/byethrow/src/functions/or-else.test.ts
@@ -64,7 +64,7 @@ describe('orElse', () => {
     describe('when output is asynchronous (Promise)', () => {
       describe('when input is a success', () => {
         const input = succeed(42);
-        const transform = vi.fn((x: string) => succeed(Promise.resolve(x.toUpperCase())));
+        const transform = vi.fn((x: string) => Promise.resolve(succeed(x.toUpperCase())));
 
         it('should return the same success', async () => {
           const result = await orElse(transform)(input);
@@ -83,7 +83,7 @@ describe('orElse', () => {
         const input = fail('error');
 
         describe('when output is a success', () => {
-          const transform = vi.fn((x: string) => succeed(Promise.resolve(x.toUpperCase())));
+          const transform = vi.fn((x: string) => Promise.resolve(succeed(x.toUpperCase())));
 
           it('should apply the function to the error', async () => {
             const result = await orElse(transform)(input);
@@ -99,7 +99,7 @@ describe('orElse', () => {
         });
 
         describe('when output is a failure', () => {
-          const transform = vi.fn((x: string) => fail(Promise.resolve(x.toUpperCase())));
+          const transform = vi.fn((x: string) => Promise.resolve(fail(x.toUpperCase())));
 
           it('should apply the function to the error', async () => {
             const result = await orElse(transform)(input);
@@ -120,7 +120,7 @@ describe('orElse', () => {
   describe('when input is asynchronous (Promise)', () => {
     describe('when output is synchronous', () => {
       describe('when input is a success', () => {
-        const input = succeed(Promise.resolve(42));
+        const input = Promise.resolve(succeed(42));
         const transform = vi.fn((x: string) => succeed(x.toUpperCase()));
 
         it('should return the same success', async () => {
@@ -137,7 +137,7 @@ describe('orElse', () => {
       });
 
       describe('when input is a failure', () => {
-        const input = fail(Promise.resolve('error'));
+        const input = Promise.resolve(fail('error'));
 
         describe('when output is a success', () => {
           const transform = vi.fn((x: string) => succeed(x.toUpperCase()));
@@ -175,8 +175,8 @@ describe('orElse', () => {
 
     describe('when output is asynchronous (Promise)', () => {
       describe('when input is a success', () => {
-        const input = succeed(Promise.resolve(42));
-        const transform = vi.fn((x: string) => succeed(Promise.resolve(x.toUpperCase())));
+        const input = Promise.resolve(succeed(42));
+        const transform = vi.fn((x: string) => Promise.resolve(succeed(x.toUpperCase())));
 
         it('should return the same success', async () => {
           const result = await orElse(transform)(input);
@@ -192,10 +192,10 @@ describe('orElse', () => {
       });
 
       describe('when input is a failure', () => {
-        const input = fail(Promise.resolve('error'));
+        const input = Promise.resolve(fail('error'));
 
         describe('when output is a success', () => {
-          const transform = vi.fn((x: string) => succeed(Promise.resolve(x.toUpperCase())));
+          const transform = vi.fn((x: string) => Promise.resolve(succeed(x.toUpperCase())));
 
           it('should apply the function to the error', async () => {
             const result = await orElse(transform)(input);
@@ -211,7 +211,7 @@ describe('orElse', () => {
         });
 
         describe('when output is a failure', () => {
-          const transform = vi.fn((x: string) => fail(Promise.resolve(x.toUpperCase())));
+          const transform = vi.fn((x: string) => Promise.resolve(fail(x.toUpperCase())));
 
           it('should apply the function to the error', async () => {
             const result = await orElse(transform)(input);

--- a/packages/byethrow/src/functions/or-through.test-d.ts
+++ b/packages/byethrow/src/functions/or-through.test-d.ts
@@ -62,7 +62,7 @@ describe('orThrough', () => {
 
       describe('when output is asynchronous (Promise)', () => {
         describe('when output is a success', () => {
-          const transform = (error: string) => succeed(Promise.resolve(error.toUpperCase()));
+          const transform = (error: string) => Promise.resolve(succeed(error.toUpperCase()));
 
           describe('when input is a success', () => {
             const input = succeed(2);
@@ -86,7 +86,7 @@ describe('orThrough', () => {
         });
 
         describe('when output is a failure', () => {
-          const transform = (error: string) => fail(Promise.resolve(error.toUpperCase()));
+          const transform = (error: string) => Promise.resolve(fail(error.toUpperCase()));
 
           describe('when input is a success', () => {
             const input = succeed(2);
@@ -117,22 +117,22 @@ describe('orThrough', () => {
           const transform = (error: string) => succeed(error.toUpperCase());
 
           describe('when input is a success', () => {
-            const input = succeed(Promise.resolve(2));
+            const input = Promise.resolve(succeed(2));
 
             it('should return a ResultAsync with original value', () => {
               const result = orThrough(transform)(input);
 
-              expectTypeOf(result).toEqualTypeOf<ResultAsync<number, never>>();
+              expectTypeOf(result).toEqualTypeOf<ResultAsync<2, never>>();
             });
           });
 
           describe('when input is a failure', () => {
-            const input = fail(Promise.resolve('error'));
+            const input = Promise.resolve(fail('error'));
 
             it('should return a ResultAsync with original error when function returns success', () => {
               const result = orThrough(transform)(input);
 
-              expectTypeOf(result).toEqualTypeOf<ResultAsync<never, string>>();
+              expectTypeOf(result).toEqualTypeOf<ResultAsync<never, 'error'>>();
             });
           });
         });
@@ -141,17 +141,17 @@ describe('orThrough', () => {
           const transform = (error: string) => fail(error.toUpperCase());
 
           describe('when input is a success', () => {
-            const input = succeed(Promise.resolve(2));
+            const input = Promise.resolve(succeed(2));
 
             it('should return a ResultAsync with original value', () => {
               const result = orThrough(transform)(input);
 
-              expectTypeOf(result).toEqualTypeOf<ResultAsync<number, string>>();
+              expectTypeOf(result).toEqualTypeOf<ResultAsync<2, string>>();
             });
           });
 
           describe('when input is a failure', () => {
-            const input = fail(Promise.resolve('error'));
+            const input = Promise.resolve(fail('error'));
 
             it('should return a ResultAsync with original error when function returns success', () => {
               const result = orThrough(transform)(input);
@@ -164,44 +164,44 @@ describe('orThrough', () => {
 
       describe('when output is asynchronous (Promise)', () => {
         describe('when output is a success', () => {
-          const transform = (error: string) => succeed(Promise.resolve(error.toUpperCase()));
+          const transform = (error: string) => Promise.resolve(succeed(error.toUpperCase()));
 
           describe('when input is a success', () => {
-            const input = succeed(Promise.resolve(2));
+            const input = Promise.resolve(succeed(2));
 
             it('should return a ResultAsync with original value', () => {
               const result = orThrough(transform)(input);
 
-              expectTypeOf(result).toEqualTypeOf<ResultAsync<number, never>>();
+              expectTypeOf(result).toEqualTypeOf<ResultAsync<2, never>>();
             });
           });
 
           describe('when input is a failure', () => {
-            const input = fail(Promise.resolve('error'));
+            const input = Promise.resolve(fail('error'));
 
             it('should return a ResultAsync with original error when function returns success', () => {
               const result = orThrough(transform)(input);
 
-              expectTypeOf(result).toEqualTypeOf<ResultAsync<never, string>>();
+              expectTypeOf(result).toEqualTypeOf<ResultAsync<never, 'error'>>();
             });
           });
         });
 
         describe('when output is a failure', () => {
-          const transform = (error: string) => fail(Promise.resolve(error.toUpperCase()));
+          const transform = (error: string) => Promise.resolve(fail(error.toUpperCase()));
 
           describe('when input is a success', () => {
-            const input = succeed(Promise.resolve(2));
+            const input = Promise.resolve(succeed(2));
 
             it('should return a ResultAsync with original value', () => {
               const result = orThrough(transform)(input);
 
-              expectTypeOf(result).toEqualTypeOf<ResultAsync<number, string>>();
+              expectTypeOf(result).toEqualTypeOf<ResultAsync<2, string>>();
             });
           });
 
           describe('when input is a failure', () => {
-            const input = fail(Promise.resolve('error'));
+            const input = Promise.resolve(fail('error'));
 
             it('should return a ResultAsync with original error when function returns success', () => {
               const result = orThrough(transform)(input);
@@ -282,7 +282,7 @@ describe('orThrough', () => {
             it('should return a ResultAsync with original value', () => {
               const result = pipe(
                 input,
-                orThrough((error: string) => succeed(Promise.resolve(error.length))),
+                orThrough((error: string) => Promise.resolve(succeed(error.length))),
               );
 
               expectTypeOf(result).toEqualTypeOf<ResultAsync<2, never>>();
@@ -295,7 +295,7 @@ describe('orThrough', () => {
             it('should return a ResultAsync with original error when function returns success', () => {
               const result = pipe(
                 input,
-                orThrough((error) => succeed(Promise.resolve(error.toUpperCase()))),
+                orThrough((error) => Promise.resolve(succeed(error.toUpperCase()))),
               );
 
               expectTypeOf(result).toEqualTypeOf<ResultAsync<number, string>>();
@@ -310,7 +310,7 @@ describe('orThrough', () => {
             it('should return a ResultAsync with original value', () => {
               const result = pipe(
                 input,
-                orThrough((error: string) => fail(Promise.resolve(error.length))),
+                orThrough((error: string) => Promise.resolve(fail(error.length))),
               );
 
               expectTypeOf(result).toEqualTypeOf<ResultAsync<2, number>>();
@@ -323,7 +323,7 @@ describe('orThrough', () => {
             it('should return a ResultAsync with original error when function returns success', () => {
               const result = pipe(
                 input,
-                orThrough((error) => fail(Promise.resolve(error.toUpperCase()))),
+                orThrough((error) => Promise.resolve(fail(error.toUpperCase()))),
               );
 
               expectTypeOf(result).toEqualTypeOf<ResultAsync<number, string>>();
@@ -337,7 +337,7 @@ describe('orThrough', () => {
       describe('when output is synchronous', () => {
         describe('when output is a success', () => {
           describe('when input is a success', () => {
-            const input = succeed(Promise.resolve(2));
+            const input = Promise.resolve(succeed(2));
 
             it('should return a ResultAsync with original value', () => {
               const result = pipe(
@@ -345,12 +345,12 @@ describe('orThrough', () => {
                 orThrough((error: string) => succeed(error.length)),
               );
 
-              expectTypeOf(result).toEqualTypeOf<ResultAsync<number, never>>();
+              expectTypeOf(result).toEqualTypeOf<ResultAsync<2, never>>();
             });
           });
 
           describe('when input is a failure', () => {
-            const input: ResultAsync<number, string> = fail(Promise.resolve('error'));
+            const input: ResultAsync<number, string> = Promise.resolve(fail('error'));
 
             it('should return a ResultAsync with original error when function returns success', () => {
               const result = pipe(
@@ -365,7 +365,7 @@ describe('orThrough', () => {
 
         describe('when output is a failure', () => {
           describe('when input is a success', () => {
-            const input = succeed(Promise.resolve(2));
+            const input = Promise.resolve(succeed(2));
 
             it('should return a ResultAsync with original value', () => {
               const result = pipe(
@@ -373,12 +373,12 @@ describe('orThrough', () => {
                 orThrough((error: string) => fail(error.length)),
               );
 
-              expectTypeOf(result).toEqualTypeOf<ResultAsync<number, number>>();
+              expectTypeOf(result).toEqualTypeOf<ResultAsync<2, number>>();
             });
           });
 
           describe('when input is a failure', () => {
-            const input: ResultAsync<number, string> = fail(Promise.resolve('error'));
+            const input: ResultAsync<number, string> = Promise.resolve(fail('error'));
 
             it('should return a ResultAsync with original error when function returns success', () => {
               const result = pipe(
@@ -395,25 +395,25 @@ describe('orThrough', () => {
       describe('when output is asynchronous (Promise)', () => {
         describe('when output is a success', () => {
           describe('when input is a success', () => {
-            const input = succeed(Promise.resolve(2));
+            const input = Promise.resolve(succeed(2));
 
             it('should return a ResultAsync with original value', () => {
               const result = pipe(
                 input,
-                orThrough((error: string) => succeed(Promise.resolve(error.length))),
+                orThrough((error: string) => Promise.resolve(succeed(error.length))),
               );
 
-              expectTypeOf(result).toEqualTypeOf<ResultAsync<number, never>>();
+              expectTypeOf(result).toEqualTypeOf<ResultAsync<2, never>>();
             });
           });
 
           describe('when input is a failure', () => {
-            const input: ResultAsync<number, string> = fail(Promise.resolve('error'));
+            const input: ResultAsync<number, string> = Promise.resolve(fail('error'));
 
             it('should return a ResultAsync with original error when function returns success', () => {
               const result = pipe(
                 input,
-                orThrough((error) => succeed(Promise.resolve(error.toUpperCase()))),
+                orThrough((error) => Promise.resolve(succeed(error.toUpperCase()))),
               );
 
               expectTypeOf(result).toEqualTypeOf<ResultAsync<number, string>>();
@@ -423,25 +423,25 @@ describe('orThrough', () => {
 
         describe('when output is a failure', () => {
           describe('when input is a success', () => {
-            const input = succeed(Promise.resolve(2));
+            const input = Promise.resolve(succeed(2));
 
             it('should return a ResultAsync with original value', () => {
               const result = pipe(
                 input,
-                orThrough((error: string) => fail(Promise.resolve(error.length))),
+                orThrough((error: string) => Promise.resolve(fail(error.length))),
               );
 
-              expectTypeOf(result).toEqualTypeOf<ResultAsync<number, number>>();
+              expectTypeOf(result).toEqualTypeOf<ResultAsync<2, number>>();
             });
           });
 
           describe('when input is a failure', () => {
-            const input: ResultAsync<number, string> = fail(Promise.resolve('error'));
+            const input: ResultAsync<number, string> = Promise.resolve(fail('error'));
 
             it('should return a ResultAsync with original error when function returns success', () => {
               const result = pipe(
                 input,
-                orThrough((error) => fail(Promise.resolve(error.toUpperCase()))),
+                orThrough((error) => Promise.resolve(fail(error.toUpperCase()))),
               );
 
               expectTypeOf(result).toEqualTypeOf<ResultAsync<number, string>>();

--- a/packages/byethrow/src/functions/or-through.test.ts
+++ b/packages/byethrow/src/functions/or-through.test.ts
@@ -82,7 +82,7 @@ describe('orThrough', () => {
 
     describe('when output is asynchronous (Promise)', () => {
       describe('when output is a success', () => {
-        const transform = vi.fn((error: string) => succeed(Promise.resolve(error.toUpperCase())));
+        const transform = vi.fn((error: string) => Promise.resolve(succeed(error.toUpperCase())));
 
         describe('when input is a success', () => {
           const input = succeed(2);
@@ -118,7 +118,7 @@ describe('orThrough', () => {
       });
 
       describe('when output is a failure', () => {
-        const transform = vi.fn((error: string) => fail(Promise.resolve(error.toUpperCase())));
+        const transform = vi.fn((error: string) => Promise.resolve(fail(error.toUpperCase())));
 
         describe('when input is a success', () => {
           const input = succeed(2);
@@ -161,7 +161,7 @@ describe('orThrough', () => {
         const transform = vi.fn((error: string) => succeed(error.toUpperCase()));
 
         describe('when input is a success', () => {
-          const input = succeed(Promise.resolve(2));
+          const input = Promise.resolve(succeed(2));
 
           it('should return the same success', async () => {
             const result = await orThrough(transform)(input);
@@ -177,7 +177,7 @@ describe('orThrough', () => {
         });
 
         describe('when input is a failure', () => {
-          const input = fail(Promise.resolve('error'));
+          const input = Promise.resolve(fail('error'));
 
           it('should return the original failure when function returns success', async () => {
             const result = await orThrough(transform)(input);
@@ -197,7 +197,7 @@ describe('orThrough', () => {
         const transform = vi.fn((error: string) => fail(error.toUpperCase()));
 
         describe('when input is a success', () => {
-          const input = succeed(Promise.resolve(2));
+          const input = Promise.resolve(succeed(2));
 
           it('should return the same success', async () => {
             const result = await orThrough(transform)(input);
@@ -213,7 +213,7 @@ describe('orThrough', () => {
         });
 
         describe('when input is a failure', () => {
-          const input = fail(Promise.resolve('error'));
+          const input = Promise.resolve(fail('error'));
 
           it('should return the original failure when function returns success', async () => {
             const result = await orThrough(transform)(input);
@@ -232,10 +232,10 @@ describe('orThrough', () => {
 
     describe('when output is asynchronous (Promise)', () => {
       describe('when output is a success', () => {
-        const transform = vi.fn((error: string) => succeed(Promise.resolve(error.toUpperCase())));
+        const transform = vi.fn((error: string) => Promise.resolve(succeed(error.toUpperCase())));
 
         describe('when input is a success', () => {
-          const input = succeed(Promise.resolve(2));
+          const input = Promise.resolve(succeed(2));
 
           it('should return the same success', async () => {
             const result = await orThrough(transform)(input);
@@ -251,7 +251,7 @@ describe('orThrough', () => {
         });
 
         describe('when input is a failure', () => {
-          const input = fail(Promise.resolve('error'));
+          const input = Promise.resolve(fail('error'));
 
           it('should return the original failure when function returns success', async () => {
             const result = await orThrough(transform)(input);
@@ -268,10 +268,10 @@ describe('orThrough', () => {
       });
 
       describe('when output is a failure', () => {
-        const transform = vi.fn((error: string) => fail(Promise.resolve(error.toUpperCase())));
+        const transform = vi.fn((error: string) => Promise.resolve(fail(error.toUpperCase())));
 
         describe('when input is a success', () => {
-          const input = succeed(Promise.resolve(2));
+          const input = Promise.resolve(succeed(2));
 
           it('should return the same success', async () => {
             const result = await orThrough(transform)(input);
@@ -287,7 +287,7 @@ describe('orThrough', () => {
         });
 
         describe('when input is a failure', () => {
-          const input = fail(Promise.resolve('error'));
+          const input = Promise.resolve(fail('error'));
 
           it('should return the original failure when function returns success', async () => {
             const result = await orThrough(transform)(input);

--- a/packages/byethrow/src/functions/sequence.test-d.ts
+++ b/packages/byethrow/src/functions/sequence.test-d.ts
@@ -31,20 +31,20 @@ describe('sequence', () => {
     describe('when some Results are asynchronous', () => {
       it('should return a ResultAsync with object of values', () => {
         const result = sequence({
-          name: succeed(Promise.resolve('Alice')),
+          name: Promise.resolve(succeed('Alice')),
           age: succeed(20),
         });
 
-        expectTypeOf(result).toEqualTypeOf<ResultAsync<{ name: string; age: 20 }, never>>();
+        expectTypeOf(result).toEqualTypeOf<ResultAsync<{ name: 'Alice'; age: 20 }, never>>();
       });
 
       it('should return a ResultAsync with error array when some fail', () => {
         const result = sequence({
-          name: succeed(Promise.resolve('Alice')),
+          name: Promise.resolve(succeed('Alice')),
           age: fail('Invalid age'),
         });
 
-        expectTypeOf(result).toEqualTypeOf<ResultAsync<{ name: string; age: never }, 'Invalid age'>>();
+        expectTypeOf(result).toEqualTypeOf<ResultAsync<{ name: 'Alice'; age: never }, 'Invalid age'>>();
       });
     });
   });
@@ -75,22 +75,22 @@ describe('sequence', () => {
     describe('when some Results are asynchronous', () => {
       it('should return a ResultAsync with array of values', () => {
         const result = sequence([
-          succeed(Promise.resolve(1)),
+          Promise.resolve(succeed(1)),
           succeed(2),
           succeed(3),
         ]);
 
-        expectTypeOf(result).toEqualTypeOf<ResultAsync<[number, 2, 3], never>>();
+        expectTypeOf(result).toEqualTypeOf<ResultAsync<[1, 2, 3], never>>();
       });
 
       it('should return a ResultAsync with error array when some fail', () => {
         const result = sequence([
-          succeed(Promise.resolve(1)),
+          Promise.resolve(succeed(1)),
           fail('error1'),
           fail('error2'),
         ]);
 
-        expectTypeOf(result).toEqualTypeOf<ResultAsync<[number, never, never], 'error1' | 'error2'>>();
+        expectTypeOf(result).toEqualTypeOf<ResultAsync<[1, never, never], 'error1' | 'error2'>>();
       });
     });
   });
@@ -112,13 +112,13 @@ describe('sequence', () => {
 
     describe('when the mapping function returns asynchronous Results', () => {
       it('should return a ResultAsync with array of mapped values', () => {
-        const result = sequence([1, 2, 3], (x) => succeed(Promise.resolve(x.toString())));
+        const result = sequence([1, 2, 3], (x) => Promise.resolve(succeed(x.toString())));
 
         expectTypeOf(result).toEqualTypeOf<ResultAsync<[string, string, string], never>>();
       });
 
       it('should return a ResultAsync with error array when some fail', () => {
-        const result = sequence([1, 2, 3], (x) => x > 1 ? fail(Promise.resolve(x.toString())) : succeed(Promise.resolve(x.toString())));
+        const result = sequence([1, 2, 3], (x) => x > 1 ? Promise.resolve(fail(x.toString())) : Promise.resolve(succeed(x.toString())));
 
         expectTypeOf(result).toEqualTypeOf<ResultAsync<[string, string, string], string>>();
       });

--- a/packages/byethrow/src/functions/sequence.test.ts
+++ b/packages/byethrow/src/functions/sequence.test.ts
@@ -53,9 +53,9 @@ describe('sequence', () => {
     describe('when some Results are asynchronous', () => {
       it('should handle async successful results', async () => {
         const result = await sequence({
-          a: succeed(Promise.resolve(1)),
-          b: succeed(Promise.resolve('hello')),
-          c: succeed(Promise.resolve(true)),
+          a: Promise.resolve(succeed(1)),
+          b: Promise.resolve(succeed('hello')),
+          c: Promise.resolve(succeed(true)),
         });
 
         expect(result).toEqual(succeed({ a: 1, b: 'hello', c: true }));
@@ -64,7 +64,7 @@ describe('sequence', () => {
       it('should handle mixed sync and async successful results', async () => {
         const result = await sequence({
           a: succeed(1),
-          b: succeed(Promise.resolve('hello')),
+          b: Promise.resolve(succeed('hello')),
           c: succeed(true),
         });
 
@@ -73,9 +73,9 @@ describe('sequence', () => {
 
       it('should stop at first async failure', async () => {
         const result = await sequence({
-          a: succeed(Promise.resolve(1)),
-          b: fail(Promise.resolve('error1')),
-          c: fail(Promise.resolve('error2')),
+          a: Promise.resolve(succeed(1)),
+          b: Promise.resolve(fail('error1')),
+          c: Promise.resolve(fail('error2')),
         });
 
         expect(result).toEqual(fail('error1'));
@@ -131,9 +131,9 @@ describe('sequence', () => {
     describe('when some Results are asynchronous', () => {
       it('should handle async successful results', async () => {
         const result = await sequence([
-          succeed(Promise.resolve(1)),
-          succeed(Promise.resolve(2)),
-          succeed(Promise.resolve(3)),
+          Promise.resolve(succeed(1)),
+          Promise.resolve(succeed(2)),
+          Promise.resolve(succeed(3)),
         ]);
 
         expect(result).toEqual(succeed([1, 2, 3]));
@@ -142,7 +142,7 @@ describe('sequence', () => {
       it('should handle mixed sync and async successful results', async () => {
         const result = await sequence([
           succeed(1),
-          succeed(Promise.resolve(2)),
+          Promise.resolve(succeed(2)),
           succeed(3),
         ]);
 
@@ -151,9 +151,9 @@ describe('sequence', () => {
 
       it('should stop at first async failure', async () => {
         const result = await sequence([
-          succeed(Promise.resolve(1)),
-          fail(Promise.resolve('error1')),
-          fail(Promise.resolve('error2')),
+          Promise.resolve(succeed(1)),
+          Promise.resolve(fail('error1')),
+          Promise.resolve(fail('error2')),
         ]);
 
         expect(result).toEqual(fail('error1'));
@@ -193,8 +193,8 @@ describe('sequence', () => {
         const result = await sequence(['1', '2', '3'], (value) => {
           const number = Number(value);
           return Number.isNaN(number)
-            ? fail(Promise.resolve(`Invalid number: ${value}`))
-            : succeed(Promise.resolve(number));
+            ? Promise.resolve(fail(`Invalid number: ${value}`))
+            : Promise.resolve(succeed(number));
         });
 
         expect(result).toEqual(succeed([1, 2, 3]));
@@ -204,8 +204,8 @@ describe('sequence', () => {
         const result = await sequence(['1', 'invalid', '3'], (value) => {
           const number = Number(value);
           return Number.isNaN(number)
-            ? fail(Promise.resolve(`Invalid number: ${value}`))
-            : succeed(Promise.resolve(number));
+            ? Promise.resolve(fail(`Invalid number: ${value}`))
+            : Promise.resolve(succeed(number));
         });
 
         expect(result).toEqual(fail('Invalid number: invalid'));

--- a/packages/byethrow/src/functions/succeed.test-d.ts
+++ b/packages/byethrow/src/functions/succeed.test-d.ts
@@ -2,19 +2,19 @@ import { describe, expectTypeOf, it } from 'vitest';
 
 import { succeed } from './succeed';
 
-import type { Result, ResultAsync } from '../result';
+import type { Result } from '../result';
 
 describe('succeed', () => {
   it('should return a Result when given a plain value', () => {
-    const result = succeed({ id: '123', name: 'Alice' });
+    const result = succeed(42);
 
-    expectTypeOf(result).toEqualTypeOf<Result<{ readonly id: '123'; readonly name: 'Alice' }, never>>();
+    expectTypeOf(result).toEqualTypeOf<Result<42, never>>();
   });
 
-  it('should return a ResultAsync when given a Promise', () => {
-    const result = succeed(Promise.resolve({ id: '123', name: 'Alice' } as const));
+  it('should return a Result when given a Promise', () => {
+    const result = succeed(Promise.resolve(42));
 
-    expectTypeOf(result).toEqualTypeOf<ResultAsync<{ readonly id: '123'; readonly name: 'Alice' }, never>>();
+    expectTypeOf(result).toEqualTypeOf<Result<Promise<number>, never>>();
   });
 
   it('should return a Result with a no value', () => {

--- a/packages/byethrow/src/functions/succeed.test.ts
+++ b/packages/byethrow/src/functions/succeed.test.ts
@@ -13,13 +13,12 @@ describe('succeed', () => {
     });
   });
 
-  it('should create a Success object with a Promise value', async () => {
-    const value = Promise.resolve({ id: '123', name: 'test' });
-    const result = await succeed(value);
+  it('should return a Result when a Promise is passed', () => {
+    const result = succeed(Promise.resolve(42));
 
     expect(result).toEqual({
       type: 'Success',
-      value: { id: '123', name: 'test' },
+      value: Promise.resolve(42),
     });
   });
 

--- a/packages/byethrow/src/functions/succeed.ts
+++ b/packages/byethrow/src/functions/succeed.ts
@@ -1,31 +1,22 @@
-/* oxlint-disable @typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-return,@typescript-eslint/no-unsafe-assignment */
+/* oxlint-disable @typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-assignment */
 
-import { isPromise } from '../internals/helpers/is-promise';
-
-import type { ResultFor } from '../result';
+import type { Result } from '../result';
 
 /**
  * Creates a {@link Success} result from a given value.
- * Automatically wraps the value in a `Promise` if it is asynchronous.
+ *
+ * Passing a `Promise` is allowed, but it is recommended to `await` it before passing to `succeed`.
  *
  * @function
  * @typeParam T - The type of the value to wrap.
- * @returns A {@link Result} or {@link ResultAsync} depending on whether the input is a promise.
+ * @returns A {@link Result} containing the given value.
  *
  * @example Synchronous Usage
  * ```ts
  * import { Result } from '@praha/byethrow';
  *
  * const result = Result.succeed(42);
- * // Result.Result<number, never>
- * ```
- *
- * @example Asynchronous Usage
- * ```ts
- * import { Result } from '@praha/byethrow';
- *
- * const result = Result.succeed(Promise.resolve(42));
- * // Result.ResultAsync<number, never>
+ * // Result.Result<42, never>
  * ```
  *
  * @example With No Value
@@ -37,20 +28,18 @@ import type { ResultFor } from '../result';
  * ```
  *
  * @see {@link collect} - For collect multiple Results into a single Result.
+ * @see {@link sequence} - For sequence multiple Results into a single Result.
  *
  * @category Creators
  */
 export const succeed: {
-  (): ResultFor<never, void, never>;
-  <const T>(value: T): ResultFor<T, Awaited<T>, never>;
-} = (...args: any[]) => {
+  (): Result<void, never>;
+  <const T>(value: T): Result<T, never>;
+} = ((...args: any[]) => {
   if (args.length <= 0) {
     return { type: 'Success', value: undefined };
   }
 
   const value = args[0];
-  if (isPromise(value)) {
-    return value.then((value) => ({ type: 'Success', value: value }));
-  }
-  return { type: 'Success', value } as any;
-};
+  return { type: 'Success', value };
+}) as any;

--- a/packages/byethrow/src/functions/try.ts
+++ b/packages/byethrow/src/functions/try.ts
@@ -90,9 +90,9 @@ const try_: {
       // oxlint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const output = options.try();
       if (isPromise(output)) {
-        const promise = succeed(output);
+        const promise = output.then((value: any) => succeed(value));
         if ('safe' in options && options.safe) return promise;
-        return promise.catch((error) => fail(options.catch(error)));
+        return promise.catch((error: any) => fail(options.catch(error)));
       }
 
       return succeed(output);

--- a/packages/byethrow/src/functions/unwrap-error.test-d.ts
+++ b/packages/byethrow/src/functions/unwrap-error.test-d.ts
@@ -43,7 +43,7 @@ describe('unwrapError', () => {
 
     describe('when input is asynchronous (Promise)', () => {
       describe('when input is a success', () => {
-        const input = succeed(Promise.resolve(42));
+        const input = Promise.resolve(succeed(42));
 
         it('should infer correct return type for async success without default', () => {
           const value = unwrapError(input);
@@ -59,7 +59,7 @@ describe('unwrapError', () => {
       });
 
       describe('when input is a failure', () => {
-        const input = fail(Promise.resolve('error'));
+        const input = Promise.resolve(fail('error'));
 
         it('should infer correct return type for async failure without default', () => {
           const value = unwrapError(input);
@@ -125,7 +125,7 @@ describe('unwrapError', () => {
 
     describe('when input is asynchronous (Promise)', () => {
       describe('when input is a success', () => {
-        const input = succeed(Promise.resolve(42));
+        const input = Promise.resolve(succeed(42));
 
         it('should infer correct return type for async success without default', () => {
           const value = pipe(
@@ -147,7 +147,7 @@ describe('unwrapError', () => {
       });
 
       describe('when input is a failure', () => {
-        const input = fail(Promise.resolve('error'));
+        const input = Promise.resolve(fail('error'));
 
         it('should infer correct return type for async failure without default', () => {
           const value = pipe(

--- a/packages/byethrow/src/functions/unwrap-error.test.ts
+++ b/packages/byethrow/src/functions/unwrap-error.test.ts
@@ -44,7 +44,7 @@ describe('unwrapError', () => {
 
   describe('when input is asynchronous (Promise)', () => {
     describe('when input is a success', () => {
-      const input = succeed(Promise.resolve(42));
+      const input = Promise.resolve(succeed(42));
 
       it('should throw the success value when no default is provided', async () => {
         await expect(unwrapError(input)).rejects.toBe(42);
@@ -58,7 +58,7 @@ describe('unwrapError', () => {
     });
 
     describe('when input is a failure', () => {
-      const input = fail(Promise.resolve('error'));
+      const input = Promise.resolve(fail('error'));
 
       it('should return the failure value', async () => {
         const result = await unwrapError(input, 99);

--- a/packages/byethrow/src/functions/unwrap.test-d.ts
+++ b/packages/byethrow/src/functions/unwrap.test-d.ts
@@ -43,7 +43,7 @@ describe('unwrap', () => {
 
     describe('when input is asynchronous (Promise)', () => {
       describe('when input is a success', () => {
-        const input = succeed(Promise.resolve(42));
+        const input = Promise.resolve(succeed(42));
 
         it('should infer correct return type for async success without default', () => {
           const value = unwrap(input);
@@ -59,7 +59,7 @@ describe('unwrap', () => {
       });
 
       describe('when input is a failure', () => {
-        const input = fail(Promise.resolve('error'));
+        const input = Promise.resolve(fail('error'));
 
         it('should infer correct return type for async failure without default', () => {
           const value = unwrap(input);
@@ -125,7 +125,7 @@ describe('unwrap', () => {
 
     describe('when input is asynchronous (Promise)', () => {
       describe('when input is a success', () => {
-        const input = succeed(Promise.resolve(42));
+        const input = Promise.resolve(succeed(42));
 
         it('should infer correct return type for async success without default', () => {
           const value = pipe(
@@ -147,7 +147,7 @@ describe('unwrap', () => {
       });
 
       describe('when input is a failure', () => {
-        const input = fail(Promise.resolve('error'));
+        const input = Promise.resolve(fail('error'));
 
         it('should infer correct return type for async failure without default', () => {
           const value = pipe(

--- a/packages/byethrow/src/functions/unwrap.test.ts
+++ b/packages/byethrow/src/functions/unwrap.test.ts
@@ -44,7 +44,7 @@ describe('unwrap', () => {
 
   describe('when input is asynchronous (Promise)', () => {
     describe('when input is a success', () => {
-      const input = succeed(Promise.resolve(42));
+      const input = Promise.resolve(succeed(42));
 
       it('should return the success value', async () => {
         const result = await unwrap(input);
@@ -60,7 +60,7 @@ describe('unwrap', () => {
     });
 
     describe('when input is a failure', () => {
-      const input = fail(Promise.resolve('error'));
+      const input = Promise.resolve(fail('error'));
 
       it('should throw the error when no default is provided', async () => {
         await expect(unwrap(input)).rejects.toBe('error');

--- a/website/docs/en/guide/tutorial/basics/creating-results.md
+++ b/website/docs/en/guide/tutorial/basics/creating-results.md
@@ -24,15 +24,12 @@ const voidSuccess = Result.succeed();
 
 ### With Async Values
 
-If you pass a `Promise`, `succeed` automatically returns a `ResultAsync`:
+`succeed` does not automatically await a `Promise`. Await the value yourself before passing it in:
 
 ```ts
 import { Result } from '@praha/byethrow';
 
-const asyncSuccess = Result.succeed(Promise.resolve('hello'));
-// Type: Result.ResultAsync<string, never>
-
-const resolved = await asyncSuccess;
+const asyncSuccess = Result.succeed(await Promise.resolve('hello'));
 // Type: Result.Result<string, never>
 ```
 
@@ -54,15 +51,12 @@ const voidFailure = Result.fail();
 
 ### With Async Errors
 
-Like `succeed`, if you pass a `Promise`, `fail` returns a `ResultAsync`:
+Like `succeed`, `fail` does not automatically await a `Promise`. Await the error yourself before passing it in:
 
 ```ts
 import { Result } from '@praha/byethrow';
 
-const asyncFailure = Result.fail(Promise.resolve('async error'));
-// Type: Result.ResultAsync<never, string>
-
-const resolved = await asyncFailure;
+const asyncFailure = Result.fail(await Promise.resolve('async error'));
 // Type: Result.Result<never, string>
 ```
 

--- a/website/docs/en/guide/tutorial/basics/result-type.md
+++ b/website/docs/en/guide/tutorial/basics/result-type.md
@@ -155,13 +155,11 @@ Asynchronous `Result` is a type alias `ResultAsync<T, E>`, representing `Promise
 ```ts
 import { Result } from '@praha/byethrow';
 
-// ResultAsync is just Promise<Result<T, E>>
-type ResultAsync<T, E> = Promise<Result.Result<T, E>>;
-
-// The library handles both sync and async seamlessly
-const asyncResult = Result.succeed(Promise.resolve(42));
+// The library provides ResultAsync<T, E> as an alias for Promise<Result<T, E>>
+const asyncResult: Result.ResultAsync<number, never> = Promise.resolve(Result.succeed(42));
 // Type: Result.ResultAsync<number, never>
 
+// ResultAsync is just Promise<Result<T, E>>, so it can be resolved with await
 const resolved = await asyncResult;
 // Type: Result.Result<number, never>
 ```

--- a/website/docs/en/guide/tutorial/combining/aggregating-results.md
+++ b/website/docs/en/guide/tutorial/combining/aggregating-results.md
@@ -242,10 +242,10 @@ When working with `ResultAsync` (asynchronous Results), `sequence` and `collect`
 import { Result } from '@praha/byethrow';
 
 const fetchUser = (id: string): Result.ResultAsync<string, string> =>
-  Result.succeed(Promise.resolve(`User ${id}`));
+  Promise.resolve(Result.succeed(`User ${id}`));
 
 const fetchOrder = (id: string): Result.ResultAsync<string, string> =>
-  Result.succeed(Promise.resolve(`Order ${id}`));
+  Promise.resolve(Result.succeed(`Order ${id}`));
 
 // Operations are executed sequentially: fetchUser completes, then fetchOrder starts
 const result = await Result.sequence({
@@ -263,10 +263,10 @@ const result = await Result.sequence({
 import { Result } from '@praha/byethrow';
 
 const fetchUser = (id: string): Result.ResultAsync<string, string> =>
-  Result.succeed(Promise.resolve(`User ${id}`));
+  Promise.resolve(Result.succeed(`User ${id}`));
 
 const fetchOrder = (id: string): Result.ResultAsync<string, string> =>
-  Result.succeed(Promise.resolve(`Order ${id}`));
+  Promise.resolve(Result.succeed(`Order ${id}`));
 
 // Operations are executed in parallel: both start at the same time
 const result = await Result.collect({

--- a/website/docs/en/guide/tutorial/resolving/unwrapping.md
+++ b/website/docs/en/guide/tutorial/resolving/unwrapping.md
@@ -101,7 +101,7 @@ Both `unwrap` and `unwrapError` work with `ResultAsync`:
 ```ts
 import { Result } from '@praha/byethrow';
 
-const asyncResult = Result.succeed(Promise.resolve(42));
+const asyncResult = Promise.resolve(Result.succeed(42));
 
 // Returns a Promise
 const value = await Result.unwrap(asyncResult);
@@ -113,7 +113,7 @@ With default:
 ```ts
 import { Result } from '@praha/byethrow';
 
-const asyncResult = Result.fail(Promise.resolve('error'));
+const asyncResult = Promise.resolve(Result.fail('error'));
 const value = await Result.unwrap(asyncResult, 0);
 // value: 0
 ```

--- a/website/docs/ja/guide/tutorial/basics/creating-results.md
+++ b/website/docs/ja/guide/tutorial/basics/creating-results.md
@@ -24,15 +24,12 @@ const voidSuccess = Result.succeed();
 
 ### 非同期値の場合
 
-`Promise` を渡すと、`succeed` は自動的に `ResultAsync` を返します。
+`succeed` は `Promise` を自動的には await しません。渡す前に自分で await してください。
 
 ```ts
 import { Result } from '@praha/byethrow';
 
-const asyncSuccess = Result.succeed(Promise.resolve('hello'));
-// 型: Result.ResultAsync<string, never>
-
-const resolved = await asyncSuccess;
+const asyncSuccess = Result.succeed(await Promise.resolve('hello'));
 // 型: Result.Result<string, never>
 ```
 
@@ -54,15 +51,12 @@ const voidFailure = Result.fail();
 
 ### 非同期エラーの場合
 
-`succeed` と同様に、`Promise` を渡すと `fail` は `ResultAsync` を返します。
+`succeed` と同様に、`fail` も `Promise` を自動的には await しません。渡す前に自分で await してください。
 
 ```ts
 import { Result } from '@praha/byethrow';
 
-const asyncFailure = Result.fail(Promise.resolve('async error'));
-// 型: Result.ResultAsync<never, string>
-
-const resolved = await asyncFailure;
+const asyncFailure = Result.fail(await Promise.resolve('async error'));
 // 型: Result.Result<never, string>
 ```
 

--- a/website/docs/ja/guide/tutorial/basics/result-type.md
+++ b/website/docs/ja/guide/tutorial/basics/result-type.md
@@ -156,13 +156,11 @@ const result = Result.pipe(
 ```ts
 import { Result } from '@praha/byethrow';
 
-// ResultAsync は単に Promise<Result<T, E>> です
-type ResultAsync<T, E> = Promise<Result.Result<T, E>>;
-
-// ライブラリは同期と非同期の両方をシームレスに扱います
-const asyncResult = Result.succeed(Promise.resolve(42));
+// ライブラリは Promise<Result<T, E>> のエイリアスとして ResultAsync<T, E> を提供しています
+const asyncResult: Result.ResultAsync<number, never> = Promise.resolve(Result.succeed(42));
 // 型: Result.ResultAsync<number, never>
 
+// ResultAsync は Promise<Result<T, E>> なので、await で解決できます
 const resolved = await asyncResult;
 // 型: Result.Result<number, never>
 ```

--- a/website/docs/ja/guide/tutorial/combining/aggregating-results.md
+++ b/website/docs/ja/guide/tutorial/combining/aggregating-results.md
@@ -247,10 +247,10 @@ parseNumbers(['1', 'abc', 'xyz']);
 import { Result } from '@praha/byethrow';
 
 const fetchUser = (id: string): Result.ResultAsync<string, string> =>
-  Result.succeed(Promise.resolve(`User ${id}`));
+  Promise.resolve(Result.succeed(`User ${id}`));
 
 const fetchOrder = (id: string): Result.ResultAsync<string, string> =>
-  Result.succeed(Promise.resolve(`Order ${id}`));
+  Promise.resolve(Result.succeed(`Order ${id}`));
 
 // 操作は順次実行される：fetchUserが完了してからfetchOrderが開始
 const result = await Result.sequence({
@@ -269,10 +269,10 @@ const result = await Result.sequence({
 import { Result } from '@praha/byethrow';
 
 const fetchUser = (id: string): Result.ResultAsync<string, string> =>
-  Result.succeed(Promise.resolve(`User ${id}`));
+  Promise.resolve(Result.succeed(`User ${id}`));
 
 const fetchOrder = (id: string): Result.ResultAsync<string, string> =>
-  Result.succeed(Promise.resolve(`Order ${id}`));
+  Promise.resolve(Result.succeed(`Order ${id}`));
 
 // 操作は並列で実行される：両方が同時に開始
 const result = await Result.collect({

--- a/website/docs/ja/guide/tutorial/resolving/unwrapping.md
+++ b/website/docs/ja/guide/tutorial/resolving/unwrapping.md
@@ -103,7 +103,7 @@ const error = Result.unwrapError(failure, 'No error');
 ```ts
 import { Result } from '@praha/byethrow';
 
-const asyncResult = Result.succeed(Promise.resolve(42));
+const asyncResult = Promise.resolve(Result.succeed(42));
 
 // Promise を返す
 const value = await Result.unwrap(asyncResult);
@@ -115,7 +115,7 @@ const value = await Result.unwrap(asyncResult);
 ```ts
 import { Result } from '@praha/byethrow';
 
-const asyncResult = Result.fail(Promise.resolve('error'));
+const asyncResult = Promise.resolve(Result.fail('error'));
 const value = await Result.unwrap(asyncResult, 0);
 // value: 0
 ```


### PR DESCRIPTION
## Background

When `succeed`/`fail` are called inside a generic function, the `ResultFor` conditional type is deferred because `HasPromise<T>` cannot be evaluated for unresolved generic type parameters. TypeScript expands it into a union of both branches (`Result | ResultAsync`), making the return value incompatible with either type. See #823.

After discussing with @Karibash, we decided to remove the Promise auto-await behavior entirely rather than try to preserve it under a non-deferring type. `succeed`/`fail` no longer special-case `Promise` arguments at all: a `Promise` passed in is now wrapped as a plain value/error, not detected or awaited. This removes the conditional (and the type deferral it caused), at the cost of breaking callers that relied on the auto-await — they should `await` the `Promise` themselves before calling `succeed`/`fail`.

## Approach

Removed the `isPromise` runtime check and the Promise-wrapping branch from both `succeed` and `fail`, and simplified their type signatures to always return a plain `Result<T, never>` regardless of whether `T` is a `Promise` (previously `ResultFor` conditionally resolved to `ResultAsync` when `T` extended `Promise`).

## Discussion

- Closes #823 and supersedes #825 (which added `succeedSync`/`succeedAsync` as an alternative approach)
- Context: https://github.com/praha-inc/byethrow/pull/825#issuecomment-4865121042

## Test Plan

- [x] `corepack pnpm lint:type` passes (byethrow core)
- [x] `corepack pnpm test` passes (all tests)

---
Generated with Claude Code
